### PR TITLE
READMEとサンプルの変更

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Example
 Low Level API example::
 
     from websocket import create_connection
-    ws = create_connection("ws://localhost:5000/echo")
+    ws = create_connection("ws://echo.websocket.org/")
     print "Sending 'Hello, World'..."
     ws.send("Hello, World")
     print "Sent"

--- a/examples/echo_client.py
+++ b/examples/echo_client.py
@@ -2,7 +2,7 @@ import websocket
 
 if __name__ == "__main__":
     websocket.enableTrace(True)
-    ws = websocket.create_connection("ws://localhost:5000/chat")
+    ws = websocket.create_connection("ws://echo.websocket.org/")
     print "Sending 'Hello, World'..."
     ws.send("Hello, World")
     print "Sent"

--- a/websocket.py
+++ b/websocket.py
@@ -173,7 +173,7 @@ class WebSocket(object):
 
     >>> import websocket
     >>> ws = websocket.WebSocket()
-    >>> ws.Connect("ws://localhost:8080/echo")
+    >>> ws.Connect("ws://echo.websocket.org")
     >>> ws.send("Hello, Server")
     >>> ws.recv()
     'Hello, Server'


### PR DESCRIPTION
こんにちは。
websocket-clientに二つの変更を加えてみました。
1. RADMEをREADME.rstにrename。Restructured Textとして処理されるのでトップページの見栄えが多少良くなったと思います。なお、無印のREADMEだと " が &quot; に変換されてしまう箇所がありますが（bug?）それも回避できます。
2. echoのサンプルをローカルのechoサーバを使う形から、websocket.orgのモノを使うように変更。websocket-clientをインストールしすぐにサンプルを試す事が出来るようになります。

もし問題なければそちらにも取り入れて頂けると助かります。
よろしくお願いします。
