### PR TITLE
Echo App Demo Throw Error: 'NoneType' object has no attribute 'opcode

### DIFF
--- a/examples/echoapp_client.py
+++ b/examples/echoapp_client.py
@@ -1,6 +1,7 @@
 import websocket
 import thread
 import time
+import sys
 
 def on_message(ws, message):
     print message
@@ -14,20 +15,27 @@ def on_close(ws):
 def on_open(ws):
     def run(*args):
         for i in range(3):
-            time.sleep(1)
+            # send the message, then wait 
+            # so thread doesnt exit and socket
+            # isnt closed
             ws.send("Hello %d" % i)
+            time.sleep(1)
+        
         time.sleep(1)
         ws.close()
-        print "thread terminating..."
+        print "Thread terminating..."
+    
     thread.start_new_thread(run, ())
-
 
 if __name__ == "__main__":
     websocket.enableTrace(True)
-    ws = websocket.WebSocketApp("ws://echo.websocket.org/",
+    if len(sys.argv) < 2:
+        host = "ws://echo.websocket.org/"
+    else:
+        host = sys.argv[1]
+    ws = websocket.WebSocketApp(host,
                                 on_message = on_message,
                                 on_error = on_error,
                                 on_close = on_close)
     ws.on_open = on_open
-    
     ws.run_forever()

--- a/websocket.py
+++ b/websocket.py
@@ -55,7 +55,6 @@ STATUS_INVALID_EXTENSION = 1010
 STATUS_UNEXPECTED_CONDITION = 1011
 STATUS_TLS_HANDSHAKE_ERROR = 1015
 
-
 logger = logging.getLogger()
 
 class WebSocketException(Exception):
@@ -515,7 +514,11 @@ class WebSocket(object):
         """
         while True:
             frame = self.recv_frame()
-            if frame.opcode in (ABNF.OPCODE_TEXT, ABNF.OPCODE_BINARY):
+            if not frame:
+                # handle error: 
+                # 'NoneType' object has no attribute 'opcode'
+                raise WebSocketException("Not a valid frame %s" % frame)
+            elif frame.opcode in (ABNF.OPCODE_TEXT, ABNF.OPCODE_BINARY):
                 return (frame.opcode, frame.data)
             elif frame.opcode == ABNF.OPCODE_CLOSE:
                 self.send_close()


### PR DESCRIPTION
this patch fixes the error, by checking for nonetype value, it also adjusts the demo code slightly to emit the send messages before the timer as to resolve problems with the socket being closed without introducing too much additional code not specific to the example/demo

finally, update patch to the demo app, fairly unsafely, to accept a url as an argument in the formt

python examples/echoapp_client.py ws://localhost/web-socket-app/

... to make integration a snap...
