### PR TITLE
Don't discard the query string when parsing the URL

### DIFF
--- a/test_websocket.py
+++ b/test_websocket.py
@@ -96,6 +96,12 @@ class WebSocketTest(unittest.TestCase):
         self.assertEquals(p[2], "/r")
         self.assertEquals(p[3], True)
 
+        p = ws._parse_url("wss://www.example.com:8080/r?key=value")
+        self.assertEquals(p[0], "www.example.com")
+        self.assertEquals(p[1], 8080)
+        self.assertEquals(p[2], "/r?key=value")
+        self.assertEquals(p[3], True)
+
         self.assertRaises(ValueError, ws._parse_url, "http://www.example.com/r")
 
     def testWSKey(self):

--- a/websocket.py
+++ b/websocket.py
@@ -132,6 +132,9 @@ def _parse_url(url):
     else:
         resource = "/"
 
+    if parsed.query:
+        resource += "?" + parsed.query
+
     return (hostname, port, resource, is_secure)
 
 def create_connection(url, timeout=None, **options):


### PR DESCRIPTION
The query string is currently discarded when parsing the URL.

Some APIs use the query string to pass authentication tokens (such as OAuth2 tokens) because the WebSockets JavaScript API doesn't support adding custom headers.
