### PR TITLE
sec-websocket-protocol shouldn't be sent by default

### DIFF
--- a/websocket.py
+++ b/websocket.py
@@ -413,7 +413,6 @@ class WebSocket(object):
    
         key = _create_sec_websocket_key()
         headers.append("Sec-WebSocket-Key: %s" % key)
-        headers.append("Sec-WebSocket-Protocol: chat, superchat")
         headers.append("Sec-WebSocket-Version: %s" % VERSION)
         if "header" in options:
             headers.extend(options["header"])


### PR DESCRIPTION
sec-websocket-protocol shouldn't be sent by default. This header defines a sub protocol that both the client and the server must speak in order for the handshake to pass.

Stricter websocket servers reject a client if this is sent and the server is not configured as a "chat" or "superchat" server.
