### PR TITLE
websocket.send fails with long data

### DIFF
--- a/websocket.py
+++ b/websocket.py
@@ -518,7 +518,9 @@ class WebSocket(object):
         if self.get_mask_key:
             frame.get_mask_key = self.get_mask_key
         data = frame.format()
-        self.io_sock.send(data)
+        while data:
+            l = self.io_sock.send(data)
+            data = data[l:]
         if traceEnabled:
             logger.debug("send: " + repr(data))
 


### PR DESCRIPTION
on slow internet connections the send command fails sometimes to send all the data in one packet. then the websocket connection is out of sync and get's interrupted.

bug appeared while gevent monkey patch was enabled. no other situations were tested.
this commit fixed the bug
