### PR TITLE
Add setup.cfg to allow py2dsc to debianize package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[egg_info]
+tag_build = 
+tag_date = 0
+tag_svn_revision = 0
+


### PR DESCRIPTION
By adding this file to the package, it allows a debian package for websocket-client
to be created this easily:

   python setup.py sdist
   cd dist
   py2dsc websocket-client-0.13.0.tar.gz
   cd deb_dist
   cd websocket-client-0.13.0
   debuild -uc -us

Without this file, py2dsc fails - in part because the process that py2dsc uses using the contents of the autogenerated egg information to decide what to package, but this misses off the autogenerate setup.cfg file. If you have a setup.cfg file, it all works as you'd hope/like.

See also #70 - Lack of setup.cfg file prevents trivial debianising

Michael.
