### PR TITLE
WebSocket now supports IPv6 URLs

### DIFF
--- a/websocket/__init__.py
+++ b/websocket/__init__.py
@@ -145,8 +145,8 @@ def _parse_url(url):
     scheme, url = url.split(":", 1)
 
     parsed = urlparse(url, scheme="http")
-    if parsed.hostname:
-        hostname = parsed.hostname
+    if parsed.netloc:
+        hostname = parsed.netloc
     else:
         raise ValueError("hostname is invalid")
     port = 0


### PR DESCRIPTION
before:

```
>>> _parse_url("wss://2a03:4000:123:83::3/ws")
('2a03', 4000, '/ws', True)
```

after:

```
>>> _parse_url("wss://2a03:4000:123:83::3/ws")
('2a03:4000:123:83::3', 443, '/ws', True)
```
