### PR TITLE
add code,reason for on_close callback 

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -193,7 +193,7 @@ class WebSocketApp(object):
         if data and len(data) >=2:
             code = 256*six.byte2int(data[0]) + six.byte2int(data[1])
             reason = data[2:].decode('utf-8')
-                return [code,reason]
+            return [code,reason]
         return [None,None]
 
     def _callback(self, callback, *args):


### PR DESCRIPTION
I'm using this code for testing of websocket implementation. I've notices that it does not return the code and reason for close operation (Which is not supported, for example, in torndao 4.0).
Javascript implementation support this (https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent)

I've tried to write pull request to implement this, not sure my implementation is clean enough. I've used inspect to check whether the on_close callback except three arguments: self, code and reason.

Hope it will help.
Eran
