### PR TITLE
support for code and reason in on_close callback

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -178,7 +178,7 @@ class WebSocketApp(object):
                 event.set()
                 thread.join()
                 self.keep_running = False
-                self.sock.close()
+            self.sock.close()
             self._callback(self.on_close,*self._get_close_args(frame.data if break_on_close_op else None))
             self.sock = None
 
@@ -186,7 +186,8 @@ class WebSocketApp(object):
         """ this functions extracts the code, reason from the close body
         if they exists, and if the self.on_close except three arguments """
         import inspect
-        if not self.on_close and len(inspect.getargspec(self.on_close).args) == 3:
+        # if the on_close callback is "old", just return empty list
+        if not self.on_close or len(inspect.getargspec(self.on_close).args) != 3:
             return []
         if data and len(data) >=2:
             code = 256*six.byte2int(data[0]) + six.byte2int(data[1])


### PR DESCRIPTION
I'm using this code for testing of websocket server implementation that uses tornado 4.0.
Tornado 4.0 supports passing code and reason for close websocket, howver this client does not support it.

Javascript standard implementation support this (https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent)

This pull request tries to add this support, it checks using inspect if the on_close callback has 3 arguments (or _args or *_kwargs), and if so pass the code and reason extracted from the frame.data.

Hope it will help.
Eran
