### PR TITLE
Add examples to sdist.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE
 include README.rst
+recursive-include examples *


### PR DESCRIPTION
When packaging it's useful to provide the examples to users who may want
to have them locally.  This adds the examples to the sdist so the source
installer can choose if they want to put the examples on their system.
