### PR TITLE
Basic low-level asynchronous abort functionality

### DIFF
--- a/websocket/_core.py
+++ b/websocket/_core.py
@@ -818,11 +818,19 @@ class WebSocket(object):
 
         self.shutdown()
 
+    def abort(self):
+        """
+        Low-level asynchonous abort, wakes up other threads that are waiting in recv_*
+        """
+        if self.connected:
+            self.sock.shutdown(socket.SHUT_RDWR)
+
     def shutdown(self):
         "close socket, immediately."
         if self.sock:
             self.sock.close()
             self.sock = None
+            self.connected = False
 
     def _send(self, data):
         if isinstance(data, six.text_type):
@@ -860,6 +868,9 @@ class WebSocket(object):
                 raise
 
         if not bytes:
+            self.sock.close()
+            self.sock = None
+            self.connected = False
             raise WebSocketConnectionClosedException()
         return bytes
 


### PR DESCRIPTION
re: upstream issue #120 
I decided to implement minimal functionality first.
abort() method kicks out readers, small changes as needed to mark connection as closed when socket disappears during recv().

This could become full-fledged async_close() in the future, although for my purposes this is enough.
