### PR TITLE
Support WEBSOCKET_CLIENT_CA_BUNDLE being directory

### DIFF
--- a/websocket/_http.py
+++ b/websocket/_http.py
@@ -135,7 +135,7 @@ def _wrap_sni_socket(sock, sslopt, hostname, check_hostname):
     context = ssl.SSLContext(sslopt.get('ssl_version', ssl.PROTOCOL_SSLv23))
 
     if sslopt.get('cert_reqs', ssl.CERT_NONE) != ssl.CERT_NONE:
-        context.load_verify_locations(cafile=sslopt.get('ca_certs', None))
+        context.load_verify_locations(cafile=sslopt.get('ca_cert', None), capath=sslopt.get('ca_cert_path', None))
     if sslopt.get('certfile', None):
         context.load_cert_chain(
             sslopt['certfile'],
@@ -170,8 +170,11 @@ def _ssl_socket(sock, user_sslopt, hostname):
     else:
         certPath = os.path.join(
             os.path.dirname(__file__), "cacert.pem")
-    if os.path.isfile(certPath) and user_sslopt.get('ca_certs', None) is None:
-        sslopt['ca_certs'] = certPath
+    if os.path.isfile(certPath) and user_sslopt.get('ca_cert', None) is None:
+        sslopt['ca_cert'] = certPath
+    elif os.path.isdir(certPath) and user_sslopt.get('ca_cert_path', None) is None:
+        sslopt['ca_cert_path'] = certPath
+        
     check_hostname = sslopt["cert_reqs"] != ssl.CERT_NONE and sslopt.pop(
         'check_hostname', True)
 


### PR DESCRIPTION
This PR adds the capability to use a directory with multiple certs to do ssl cert verification. Similar to how the requests module uses REQUESTS_CA_BUNDLE.