### PR TITLE
Avoid the app to block on close on certain systems

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -197,7 +197,7 @@ class WebSocketApp(object):
 
             while self.sock.connected:
                 r, w, e = select.select(
-                    (self.sock.sock, ), (), (), ping_timeout)
+                    (self.sock.sock, ), (), (), ping_timeout or 10) # Use a 10 second timeout to avoid to wait forever on close
                 if not self.keep_running:
                     break
 


### PR DESCRIPTION
This relates to issues #317

From the man page of libc/select:

> Multithreaded applications
> If a file descriptor being monitored by select() is closed in another thread, the result is unspecified.  On some UNIX systems, select() unblocks and returns, with an indication that the file descriptor is ready (a subsequent I/O operation will likely fail with an error, unless another the file descriptor reopened between the time select() returned and the I/O operations was performed).  On Linux (and some other systems), closing the file descriptor in another thread has no effect on select().  In summary, any application that relies on a particular behavior in this scenario must be considered buggy.

This change ensures that select unlock at least every 10 sec