### PR TITLE
renames key in sslopt dict, fixes #326

### DIFF
--- a/websocket/_http.py
+++ b/websocket/_http.py
@@ -171,7 +171,7 @@ def _ssl_socket(sock, user_sslopt, hostname):
         certPath = os.path.join(
             os.path.dirname(__file__), "cacert.pem")
     if os.path.isfile(certPath) and user_sslopt.get('ca_cert', None) is None:
-        sslopt['ca_cert'] = certPath
+        sslopt['ca_certs'] = certPath
     elif os.path.isdir(certPath) and user_sslopt.get('ca_cert_path', None) is None:
         sslopt['ca_cert_path'] = certPath
 


### PR DESCRIPTION
must use the same key in the `sslopt` dictionary when reading and writing to it.

as mentioned after the issue was closed, the issue still existed. i made this change locally and verified that the issue is fixed.

**NOTE:** the API for `connect()` (internally called by `websocket.create_connection()`) allows the user to specify `sslopts`. This dict param still uses the `ca_cert` key, so as to not introduce a breaking change to the API.