### PR TITLE
Ensure cookie items are sorted

### DIFF
--- a/websocket/_cookiejar.py
+++ b/websocket/_cookiejar.py
@@ -49,4 +49,4 @@ class SimpleCookieJar(object):
                 cookies.append(self.jar.get(domain))
 
         return "; ".join(filter(None, ["%s=%s" % (k, v.value) for cookie in filter(None, sorted(cookies)) for k, v in
-                                       cookie.items()]))
+                                       sorted(cookie.items())]))


### PR DESCRIPTION
Ensure that values stored inside a Cookie are sorted as the
contents of a CookieJar are retrieved.

This resolves some non-deterministic behaviour on some Python
versions where dictionary iteration order happens to not be
deterministic.

Fixes: #337