### PR TITLE
Resolve a proxy issue and a connection error

### DIFF
--- a/websocket/_http.py
+++ b/websocket/_http.py
@@ -114,7 +114,11 @@ def _open_socket(addrinfo_list, sockopt, timeout):
             sock.connect(address)
         except socket.error as error:
             error.remote_ip = str(address[0])
-            if error.errno in (errno.ECONNREFUSED, ):
+            try:
+                eConnRefused = (errno.ECONNREFUSED, errno.WSAECONNREFUSED)
+            except:
+                eConnRefused = (errno.ECONNREFUSED, )
+            if error.errno in eConnRefused:
                 err = error
                 continue
             else:

--- a/websocket/_http.py
+++ b/websocket/_http.py
@@ -47,11 +47,10 @@ class proxy_info(object):
         if self.host:
             self.port = options.get("http_proxy_port", 0)
             self.auth = options.get("http_proxy_auth", None)
-            self.no_proxy = options.get("http_no_proxy", None)
         else:
             self.port = 0
             self.auth = None
-            self.no_proxy = None
+        self.no_proxy = options.get("http_no_proxy", None)
 
 
 def connect(url, options, proxy, socket):


### PR DESCRIPTION
I made these two changes to be able to run websocket-client in my environment.  I have HTTP_PROXY set but the websocket server I'm trying to use is local.  I also needed to catch the WSAECONNREFUSED error which was being thrown while attempting to connect to the IPv6 address of the host.  I believe this error is windows specific, so I used the try/except.

I tested it in Windows 10 with python 2.7.8