### PR TITLE
Wrap socket.gaierror with subclass of WebsocketException

### DIFF
--- a/websocket/_exceptions.py
+++ b/websocket/_exceptions.py
@@ -78,3 +78,9 @@ class WebSocketBadStatusException(WebSocketException):
         super(WebSocketBadStatusException, self).__init__(
             message % status_code)
         self.status_code = status_code
+
+class WebSocketAddressException(WebSocketException):
+    """
+    If the websocket address info cannot be found, this exception will be raised.
+    """
+    pass

--- a/websocket/_http.py
+++ b/websocket/_http.py
@@ -88,14 +88,17 @@ def connect(url, options, proxy, socket):
 def _get_addrinfo_list(hostname, port, is_secure, proxy):
     phost, pport, pauth = get_proxy_info(
         hostname, is_secure, proxy.host, proxy.port, proxy.auth, proxy.no_proxy)
-    if not phost:
-        addrinfo_list = socket.getaddrinfo(
-            hostname, port, 0, 0, socket.SOL_TCP)
-        return addrinfo_list, False, None
-    else:
-        pport = pport and pport or 80
-        addrinfo_list = socket.getaddrinfo(phost, pport, 0, 0, socket.SOL_TCP)
-        return addrinfo_list, True, pauth
+    try:
+        if not phost:
+            addrinfo_list = socket.getaddrinfo(
+                hostname, port, 0, 0, socket.SOL_TCP)
+            return addrinfo_list, False, None
+        else:
+            pport = pport and pport or 80
+            addrinfo_list = socket.getaddrinfo(phost, pport, 0, 0, socket.SOL_TCP)
+            return addrinfo_list, True, pauth
+    except socket.gaierror as e:
+        raise WebSocketAddressException(e)
 
 
 def _open_socket(addrinfo_list, sockopt, timeout):


### PR DESCRIPTION
Allows users of the library to catch WebSocketException with blissful naivety.