### PR TITLE
Fix SSL: SSLV3_ALERT_HANDSHAKE_FAILURE on Debian Stretch

### DIFF
--- a/websocket/_http.py
+++ b/websocket/_http.py
@@ -152,6 +152,8 @@ def _wrap_sni_socket(sock, sslopt, hostname, check_hostname):
     if 'cert_chain' in sslopt:
         certfile, keyfile, password = sslopt['cert_chain']
         context.load_cert_chain(certfile, keyfile, password)
+    if 'ecdh_curve' in sslopt:
+        context.set_ecdh_curve(sslopt['ecdh_curve'])
 
     return context.wrap_socket(
         sock,


### PR DESCRIPTION
Hi !

I recently switch from Debian Whezzy to Debian Stretch, and websocket stopped working with wss protocol. I have following error:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "websocket/_core.py", line 211, in connect
    options.pop('socket', None))
  File "websocket/_http.py", line 77, in connect
    sock = _ssl_socket(sock, options.sslopt, hostname)
  File "websocket/_http.py", line 183, in _ssl_socket
    sock = _wrap_sni_socket(sock, sslopt, hostname, check_hostname)
  File "websocket/_http.py", line 161, in _wrap_sni_socket
    server_hostname=hostname,
  File "/usr/lib/python2.7/ssl.py", line 363, in wrap_socket
    _context=self)
  File "/usr/lib/python2.7/ssl.py", line 611, in __init__
    self.do_handshake()
  File "/usr/lib/python2.7/ssl.py", line 840, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLError: [SSL: SSLV3_ALERT_HANDSHAKE_FAILURE] sslv3 alert handshake failure (_ssl.c:661)
```
when same code and same parameters work like a charm on other OS.

I eventually find a solution from [this issue](https://github.com/matrix-org/synapse/issues/2350). Forcing a curve name through `SSLContext.set_ecdh_curve` is a nice workaround.

I propose a merge request so that user can set this option via `sslopt`, as:

```
ws = websocket.WebSocket(sslopt={'ecdh_curve': 'secp384r1'})
```

Thanks for your work !