### PR TITLE
Parse close frame response correctly when reason present

### DIFF
--- a/websocket/_core.py
+++ b/websocket/_core.py
@@ -393,7 +393,7 @@ class WebSocket(object):
                 try:
                     frame = self.recv_frame()
                     if isEnabledForError():
-                        recv_status = struct.unpack("!H", frame.data)[0]
+                        recv_status = struct.unpack("!H", frame.data[0:2])[0]
                         if recv_status != STATUS_NORMAL:
                             error("close status: " + repr(recv_status))
                 except:


### PR DESCRIPTION
The line here originally threw an exception if a reason was present in the responding close frame data, since that makes it longer than the assumed two bytes.  The exception is caught obviously, but the following if statement won't execute.