### PR TITLE
add lock to recv function

### DIFF
--- a/websocket/_core.py
+++ b/websocket/_core.py
@@ -94,8 +94,10 @@ class WebSocket(object):
 
         if enable_multithread:
             self.lock = threading.Lock()
+            self.readlock = threading.Lock()
         else:
             self.lock = NoLock()
+            self.readlock = NoLock()
 
     def __iter__(self):
         """
@@ -290,7 +292,7 @@ class WebSocket(object):
 
         return value: string(byte array) value.
         """
-        with self.lock:
+        with self.readlock:
             opcode, data = self.recv_data()
         if six.PY3 and opcode == ABNF.OPCODE_TEXT:
             return data.decode("utf-8")

--- a/websocket/_core.py
+++ b/websocket/_core.py
@@ -290,7 +290,8 @@ class WebSocket(object):
 
         return value: string(byte array) value.
         """
-        opcode, data = self.recv_data()
+        with self.lock:
+            opcode, data = self.recv_data()
         if six.PY3 and opcode == ABNF.OPCODE_TEXT:
             return data.decode("utf-8")
         elif opcode == ABNF.OPCODE_TEXT or opcode == ABNF.OPCODE_BINARY:


### PR DESCRIPTION
The `enable_multithread` option created a lock, but it is only used when sending messages. This PR adds to locking to receiving as well.