### PR TITLE
Update example for python3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,10 @@ This example is similar to how WebSocket code looks in browsers using JavaScript
 .. code:: python
 
     import websocket
-    import thread
+    try:
+        import thread
+    except ImportError:
+        import _thread as thread
     import time
 
     def on_message(ws, message):


### PR DESCRIPTION
`thread` has been renamed `_thread` in python3.