### PR TITLE
Init logging properly

### DIFF
--- a/websocket/_logging.py
+++ b/websocket/_logging.py
@@ -21,6 +21,7 @@ Copyright (C) 2010 Hiroki Ohtani(liris)
 """
 import logging
 
+logging.basicConfig()
 _logger = logging.getLogger('websocket')
 _traceEnabled = False
 


### PR DESCRIPTION
Init logging properly. Otherwise a user won't see any messages. Instead, a user will see the following error 'No handlers could be found for logger'. 
This issue occurred when I wrote faulty code in my on_message handler. As a result, I got the above error.