### PR TITLE
cross-platform aync multi-client solution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import pkg_resources
 VERSION = "0.46.0"
 NAME = "websocket_client"
 
-install_requires = ["six"]
+install_requires = ["six", "rel"]
 tests_require = []
 
 if sys.version_info[0] == 2 and sys.version_info[1] < 7:

--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -177,6 +177,8 @@ class WebSocketApp(object):
         self.keep_running = True
 
         def teardown():
+            if not self.keep_running:
+                return
             if thread and thread.isAlive():
                 event.set()
                 thread.join()
@@ -215,7 +217,7 @@ class WebSocketApp(object):
                 op_code, frame = self.sock.recv_data_frame(True)
                 if op_code == ABNF.OPCODE_CLOSE:
                     close_frame = frame
-                    return
+                    return teardown()
                 elif op_code == ABNF.OPCODE_PING:
                     self._callback(self.on_ping, frame.data)
                 elif op_code == ABNF.OPCODE_PONG:

--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -242,6 +242,7 @@ class WebSocketApp(object):
                 return True
 
             rel.read(self.sock.sock, read)
+            rel.signal(2, rel.abort)
             no_dispatch or rel.dispatch()
         except (Exception, KeyboardInterrupt, SystemExit) as e:
             self._callback(self.on_error, e)

--- a/websocket/_socket.py
+++ b/websocket/_socket.py
@@ -65,7 +65,6 @@ def setdefaulttimeout(timeout):
     global _default_timeout
     _default_timeout = timeout
 
-c
 def getdefaulttimeout():
     """
     Return the global timeout setting(second) to connect.


### PR DESCRIPTION
I modified WebSocketApp.run_forever(), replacing the select() loop with rel.read() event registration. Info on rel here:

https://github.com/bubbleboy14/registeredeventlistener

This addresses platform issues (e.g. https://github.com/websocket-client/websocket-client/pull/293/files) by choosing the fastest async method (such as epoll, poll, kqueue, select) supported by the system.

Furthermore, one can now run more than one WebSocketApp by simply passing no_dispatch=True to run_forever() as many times as are necessary (n-1 times -> all but the last, which will finally start the event loop).