### PR TITLE
Fixes raising WebSocketTimeoutException with SSL

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,10 @@
 ChangeLog
 ============
 
+- 0.48.0
+
+  -Fix detecting timeouts with SSL in recv (#387)
+
 - 0.47.0
 
   - Fix socket constructor in _open_socket to use all relevant variables from getaddrinfo. (#383)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 from setuptools import setup
 import pkg_resources
 
-VERSION = "0.47.0"
+VERSION = "0.48.0"
 NAME = "websocket_client"
 
 install_requires = ["six"]

--- a/websocket/__init__.py
+++ b/websocket/__init__.py
@@ -26,4 +26,4 @@ from ._exceptions import *
 from ._logging import *
 from ._socket import *
 
-__version__ = "0.47.0"
+__version__ = "0.48.0"

--- a/websocket/_socket.py
+++ b/websocket/_socket.py
@@ -84,7 +84,7 @@ def recv(sock, bufsize):
         raise WebSocketTimeoutException(message)
     except SSLError as e:
         message = extract_err_message(e)
-        if message == "The read operation timed out":
+        if isinstance(message, str) and 'timed out' in message:
             raise WebSocketTimeoutException(message)
         else:
             raise


### PR DESCRIPTION
The previous message used for detecting SSL was too specific and was
missing cases where SSL simply returned "timed out".  This patch changes
the detection to mirror what is done in the send for detecting timeouts.

Fixes #387

Signed-off-by: Tim Rozet <tdrozet@gmail.com>