### PR TITLE
Simplified Dispatcher API

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -244,7 +244,6 @@ class WebSocketApp(object):
                 return True
 
             dispatcher.read(self.sock.sock, read)
-            dispatcher.dispatch()
         except (Exception, KeyboardInterrupt, SystemExit) as e:
             self._callback(self.on_error, e)
             if isinstance(e, SystemExit):
@@ -260,10 +259,6 @@ class WebSocketApp(object):
                     (self.sock.sock, ), (), (), ping_timeout or 10) # Use a 10 second timeout to avoid to wait forever on close
                     if r:
                         callback()
-
-            def dispatch(_):
-                # do nothing
-                pass
 
         return Dispatcher()
 


### PR DESCRIPTION
Love the new run_forever(dispatcher=something) interface. I have one suggestion to make it simpler and more broadly applicable.

I removed explicit dispatching for two reasons: 

 - by default, this function is empty, and isn't even called
 - this allows users to easily drop in dispatchers, such as pure-Python [rel](https://github.com/bubbleboy14/registeredeventlistener) and the ever-popular C-based [pyevent](https://www.developerfusion.com/project/39066/pyevent/)

With this API, multi-headed applications are quite simple:

```
import rel, websocket

def on_message(ws, message):
	print ws.symbol, message

def spawn(symbol):
	ws = websocket.WebSocketApp("wss://api.gemini.com/v1/marketdata/%s"%(symbol,),
		on_message=on_message)
	ws.symbol = symbol
	ws.run_forever(dispatcher=rel)

for symbol in ["BTCUSD", "ETHUSD", "ETHBTC"]:
    spawn(symbol)

rel.signal(2, rel.abort) # Keyboard Interrupt
rel.dispatch()
```