### PR TITLE
fix #395

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -204,6 +204,8 @@ class WebSocketApp(object):
         thread = None
         close_frame = None
         self.keep_running = True
+        self.last_ping_tm = 0
+        self.last_pong_tm = 0
 
         def teardown():
             if not self.keep_running:


### PR DESCRIPTION
Reset ping/pong timestamp in the WebSocketApp.run_forever method.