### PR TITLE
Fix the issue that websocket status message may not present

### DIFF
--- a/websocket/_http.py
+++ b/websocket/_http.py
@@ -242,7 +242,8 @@ def read_headers(sock):
 
             status_info = line.split(" ", 2)
             status = int(status_info[1])
-            status_message = status_info[2]
+            if len(status_info) > 2:
+                status_message = status_info[2]
         else:
             kv = line.split(":", 1)
             if len(kv) == 2:


### PR DESCRIPTION
It is observed that in some websocket server implementation, the status message in the header may not be set.  In this case using this library will pop up a 'list index out of range' error.

Add a check before we extracting the status_message to avoid the issue.