### PR TITLE
Allow server to not send a status text

### DIFF
--- a/websocket/_http.py
+++ b/websocket/_http.py
@@ -242,7 +242,7 @@ def read_headers(sock):
 
             status_info = line.split(" ", 2)
             status = int(status_info[1])
-            status_message = status_info[2]
+            status_message = status_info[2] if len(status_info) > 2 else ''
         else:
             kv = line.split(":", 1)
             if len(kv) == 2:


### PR DESCRIPTION
Even though this doesn't conform to the HTTP protocol, the client should be resilient to the server's misbehavior

This resolves #406