### PR TITLE
Fix waiting forever on ping/pong timeout

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -49,7 +49,8 @@ class Dispatcher:
             r, w, e = select.select(
             (self.app.sock.sock, ), (), (), self.ping_timeout) # Use a 10 second timeout to avoid to wait forever on close
             if r:
-                read_callback()
+                if not read_callback():
+                    break
             check_callback()
 
 class SSLDispacther:
@@ -61,7 +62,8 @@ class SSLDispacther:
         while self.app.sock.connected:
             r = self.select()
             if r:
-                read_callback()
+                if not read_callback():
+                    break
             check_callback()
 
     def select(self):

--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -44,23 +44,25 @@ class Dispatcher:
         self.app  = app
         self.ping_timeout = ping_timeout
 
-    def read(self, sock, callback):
+    def read(self, sock, read_callback, check_callback):
         while self.app.sock.connected:
             r, w, e = select.select(
             (self.app.sock.sock, ), (), (), self.ping_timeout) # Use a 10 second timeout to avoid to wait forever on close
             if r:
-                callback()
+                read_callback()
+            check_callback()
 
 class SSLDispacther:
     def __init__(self, app, ping_timeout):
         self.app  = app
         self.ping_timeout = ping_timeout
 
-    def read(self, sock, callback):
+    def read(self, sock, read_callback, check_callback):
         while self.app.sock.connected:
             r = self.select()
             if r:
-                callback()
+                read_callback()
+            check_callback()
 
     def select(self):
         sock = self.app.sock.sock
@@ -269,13 +271,16 @@ class WebSocketApp(object):
                     self._callback(self.on_data, data, frame.opcode, True)
                     self._callback(self.on_message, data)
 
+                return True
+
+            def check():
                 if ping_timeout and self.last_ping_tm \
                         and time.time() - self.last_ping_tm > ping_timeout \
                         and self.last_ping_tm - self.last_pong_tm > ping_timeout:
                     raise WebSocketTimeoutException("ping/pong timed out")
                 return True
 
-            dispatcher.read(self.sock.sock, read)
+            dispatcher.read(self.sock.sock, read, check)
         except (Exception, KeyboardInterrupt, SystemExit) as e:
             self._callback(self.on_error, e)
             if isinstance(e, SystemExit):


### PR DESCRIPTION
Test case:

```python
import websocket

websocket.enableTrace(True)

ws = websocket.WebSocketApp(
    'wss://stream.binance.com:9443/ws/btcusdt@ticker',
    on_message=lambda _, msg: print('Message:', msg),
    on_close=lambda _: print('Close'),
    on_error=lambda _, e: print('Error:', e))

ws.run_forever(ping_interval=4, ping_timeout=2)
```

Current version, if a network failure occurs, simply blocks forever. This is because timeouts are only checked when the there is data available to read, not simply when `select` returns.