### PR TITLE
socks5 via pysocks support

### DIFF
--- a/websocket/_url.py
+++ b/websocket/_url.py
@@ -117,7 +117,7 @@ def _is_no_proxy_host(hostname, no_proxy):
 
 def get_proxy_info(
         hostname, is_secure, proxy_host=None, proxy_port=0, proxy_auth=None,
-        no_proxy=None):
+        no_proxy=None, proxy_type='http'):
     """
     try to retrieve proxy host and port from environment
     if not provided in options.
@@ -137,6 +137,9 @@ def get_proxy_info(
                 "http_proxy_auth" - http proxy auth information.
                                     tuple of username and password.
                                     default is None
+                "proxy_type"      - if set to "socks5" PySocks wrapper
+                                    will be used in place of a http proxy.
+                                    default is "http"
     """
     if _is_no_proxy_host(hostname, no_proxy):
         return None, 0, None


### PR DESCRIPTION
After reading #362, I feel there might be little interest in this patch, but here goes nothing :)

This adds a new config option `proxy_type`, and when it's set to `socks4`, `socks5` or `socks5h`, pysocks gets invoked (so the dependency is soft). Although pysocks supports HTTP proxies too (and probably does it well), this patch chooses the original/internal websocket-client implementation for backwards-compatibility.

pysocks is kinda the de-facto standard for wrapping sockets into socks proxies, and having support for it built-in right into websocket-client, would be *enormously* helpful (to me, anyways). I do realize you can work around via `_create_connection`, but it gets really messy when you a) involve SSL and b) want to implement it to every websocket-based RPC you use.

Hopefully this is reasonable and/or helpful, please let me know if I can improve this patch somehow.