### PR TITLE
Fix For Issue #410 - setting keep_running to false has no effect

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -208,8 +208,6 @@ class WebSocketApp(object):
         self.last_pong_tm = 0
 
         def teardown():
-            if not self.keep_running:
-                return
             if thread and thread.isAlive():
                 event.set()
                 thread.join()


### PR DESCRIPTION
Fix Issue #410 .  Currently, setting keep_running to false results in read continually calling teardown() but never completing the teardown.

Before 0.47.0 this caused the websocketapp to shutdown.  Calling close() instead will work but can have errors as described in issue #414 

Not sure if this return condition was left in teardown() on purpose or not.  Reject if it is needed for some reason!

Another suggestion, add a stop_running() method or similar to websocketapp so it can be turned off after run_forever().  Better encapsulation than setting the boolean directly, but this fix solves the issue of transitioning from 0.46.0.