### PR TITLE
fix: upgrade status message may missing

### DIFF
--- a/websocket/_http.py
+++ b/websocket/_http.py
@@ -242,7 +242,7 @@ def read_headers(sock):
 
             status_info = line.split(" ", 2)
             status = int(status_info[1])
-            status_message = status_info[2]
+            status_message = status_info[2] if len(status_info) == 3 else ""
         else:
             kv = line.split(":", 1)
             if len(kv) == 2:


### PR DESCRIPTION
a tomcat websocket impliment will send status line `HTTP/1.1 101 \r\n`, breaks our parsing.