### PR TITLE
_http.py: fix windows proxy error due to socktype

### DIFF
--- a/websocket/_http.py
+++ b/websocket/_http.py
@@ -94,7 +94,11 @@ def _get_addrinfo_list(hostname, port, is_secure, proxy):
             return addrinfo_list, False, None
         else:
             pport = pport and pport or 80
-            addrinfo_list = socket.getaddrinfo(phost, pport, 0, 0, socket.SOL_TCP)
+            # when running on windows 10, the getaddrinfo used above
+            # returns a socktype 0. This generates an error exception:
+            #_on_error: exception Socket type must be stream or datagram, not 0
+            # Force the socket type to SOCK_STREAM
+            addrinfo_list = socket.getaddrinfo(phost, pport, 0, socket.SOCK_STREAM, socket.SOL_TCP)
             return addrinfo_list, True, pauth
     except socket.gaierror as e:
         raise WebSocketAddressException(e)


### PR DESCRIPTION
Resolves #426
When running on windows 10 with a proxy, there is a connect error:
_on_error: exception Socket type must be stream or datagram, not 0

This commit fixes that issue.

Signed-off-by: Paul Barrette <paulbarrette@gmail.com>