### PR TITLE
Update supported Python versions (2.7, 3.4+)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - '3.6'
   - '3.7'
   - '3.8'
+  - '3.9-dev'
   - 'pypy'
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ python:
   - '3.7'
   - '3.8'
   - 'pypy'
-  - 'nightly'
 
 install:
   - pip install -U pip setuptools wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: python
 
-matrix:
-  include:
-    - python: '2.7'
-    - python: '3.4'
-    - python: '3.5'
-    - python: '3.6'
-    - python: '3.7'
-      dist: xenial
-      sudo: true
+python:
+  - '2.7'
+  - '3.4'
+  - '3.5'
+  - '3.6'
+  - '3.7'
+  - '3.8'
+  - 'pypy'
+  - 'nightly'
 
 install:
   - pip install -U pip setuptools wheel

--- a/bin/wsdump.py
+++ b/bin/wsdump.py
@@ -165,7 +165,7 @@ def main():
             if not args.verbose and opcode in OPCODE_DATA:
                 msg = data
             elif args.verbose:
-                msg = "%s: %s" % (websocket.ABNF.OPCODE_MAP.get(opcode), data)
+                msg = "{}: {}".format(websocket.ABNF.OPCODE_MAP.get(opcode), data)
 
             if msg is not None:
                 if args.timings:

--- a/compliance/test_fuzzingclient.py
+++ b/compliance/test_fuzzingclient.py
@@ -15,7 +15,7 @@ ws.close()
 
 
 for case in range(1, count+1):
-    url = SERVER + '/runCase?case={0}&agent={1}'.format(case, AGENT)
+    url = SERVER + '/runCase?case={}&agent={}'.format(case, AGENT)
     status = websocket.STATUS_NORMAL
     try:
         ws = websocket.create_connection(url)
@@ -39,5 +39,5 @@ for case in range(1, count+1):
         ws.close(status)
 
 print("Ran {} test cases.".format(case))
-url = SERVER + '/updateReports?agent={0}'.format(AGENT)
+url = SERVER + '/updateReports?agent={}'.format(AGENT)
 ws = websocket.create_connection(url)

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX",
         "Operating System :: Microsoft :: Windows",

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX",
         "Operating System :: Microsoft :: Windows",

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     author_email="liris.pp@gmail.com",
     license="BSD",
     url="https://github.com/websocket-client/websocket-client.git",
-    python_requires='>=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     classifiers=[
         "Development Status :: 4 - Beta",
         "License :: OSI Approved :: BSD License",

--- a/setup.py
+++ b/setup.py
@@ -7,17 +7,12 @@ VERSION = "0.56.0"
 NAME = "websocket_client"
 
 install_requires = ["six"]
-tests_require = []
 
-if sys.version_info[0] == 2 and sys.version_info[1] < 7:
-        tests_require.append('unittest2==0.8.0')
-
-insecure_pythons = '2.6, ' + ', '.join("2.7.{pv}".format(pv=pv) for pv in range(10))
+insecure_pythons = ''.join("2.7.{pv}".format(pv=pv) for pv in range(10))
 
 extras_require = {
     ':python_version in "{ips}"'.format(ips=insecure_pythons):
         ['backports.ssl_match_hostname'],
-    ':python_version in "2.6"': ['argparse'],
 }
 
 try:
@@ -50,7 +45,6 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.4",
@@ -71,6 +65,5 @@ setup(
     package_data={
         'websocket.tests': ['data/*.txt']
     },
-    tests_require=tests_require,
     test_suite="websocket.tests"
 )

--- a/websocket/_cookiejar.py
+++ b/websocket/_cookiejar.py
@@ -48,5 +48,5 @@ class SimpleCookieJar(object):
             if host.endswith(domain) or host == domain[1:]:
                 cookies.append(self.jar.get(domain))
 
-        return "; ".join(filter(None, ["%s=%s" % (k, v.value) for cookie in filter(None, sorted(cookies)) for k, v in
+        return "; ".join(filter(None, ["{}={}".format(k, v.value) for cookie in filter(None, sorted(cookies)) for k, v in
                                        sorted(cookie.items())]))

--- a/websocket/tests/test_cookiejar.py
+++ b/websocket/tests/test_cookiejar.py
@@ -20,12 +20,12 @@ class CookieJarTest(unittest.TestCase):
 
         cookie_jar = SimpleCookieJar()
         cookie_jar.add("a=b; domain=.abc")
-        self.assertTrue(".abc" in cookie_jar.jar)
+        self.assertIn(".abc", cookie_jar.jar)
 
         cookie_jar = SimpleCookieJar()
         cookie_jar.add("a=b; domain=abc")
-        self.assertTrue(".abc" in cookie_jar.jar)
-        self.assertTrue("abc" not in cookie_jar.jar)
+        self.assertIn(".abc", cookie_jar.jar)
+        self.assertNotIn("abc", cookie_jar.jar)
 
         cookie_jar = SimpleCookieJar()
         cookie_jar.add("a=b; c=d; domain=abc")
@@ -55,12 +55,12 @@ class CookieJarTest(unittest.TestCase):
 
         cookie_jar = SimpleCookieJar()
         cookie_jar.set("a=b; domain=.abc")
-        self.assertTrue(".abc" in cookie_jar.jar)
+        self.assertIn(".abc", cookie_jar.jar)
 
         cookie_jar = SimpleCookieJar()
         cookie_jar.set("a=b; domain=abc")
-        self.assertTrue(".abc" in cookie_jar.jar)
-        self.assertTrue("abc" not in cookie_jar.jar)
+        self.assertIn(".abc", cookie_jar.jar)
+        self.assertNotIn("abc", cookie_jar.jar)
 
         cookie_jar = SimpleCookieJar()
         cookie_jar.set("a=b; c=d; domain=abc")

--- a/websocket/tests/test_websocket.py
+++ b/websocket/tests/test_websocket.py
@@ -9,6 +9,7 @@ import os.path
 import socket
 
 import six
+import unittest
 
 # websocket-client
 import websocket as ws
@@ -22,11 +23,6 @@ if six.PY3:
     from base64 import decodebytes as base64decode
 else:
     from base64 import decodestring as base64decode
-
-if sys.version_info[0] == 2 and sys.version_info[1] < 7:
-    import unittest2 as unittest
-else:
-    import unittest
 
 try:
     from ssl import SSLError
@@ -153,9 +149,6 @@ class WebSocketTest(unittest.TestCase):
         self.assertEqual(p[3], True)
 
         self.assertRaises(ValueError, parse_url, "http://www.example.com/r")
-
-        if sys.version_info[0] == 2 and sys.version_info[1] < 7:
-            return
 
         p = parse_url("ws://[2a03:4000:123:83::3]/r")
         self.assertEqual(p[0], "2a03:4000:123:83::3")

--- a/websocket/tests/test_websocket.py
+++ b/websocket/tests/test_websocket.py
@@ -88,7 +88,7 @@ class WebSocketTest(unittest.TestCase):
         pass
 
     def testDefaultTimeout(self):
-        self.assertEqual(ws.getdefaulttimeout(), None)
+        self.assertIsNone(ws.getdefaulttimeout())
         ws.setdefaulttimeout(10)
         self.assertEqual(ws.getdefaulttimeout(), 10)
         ws.setdefaulttimeout(None)
@@ -176,8 +176,8 @@ class WebSocketTest(unittest.TestCase):
 
     def testWSKey(self):
         key = _create_sec_websocket_key()
-        self.assertTrue(key != 24)
-        self.assertTrue(six.u("¥n") not in key)
+        self.assertNotEqual(key, 24)
+        self.assertNotIn(six.u("¥n"), key)
 
     def testWsUtils(self):
         key = "c6b8hTg4EeGb2gQMztV1/g=="


### PR DESCRIPTION
Python 2.6 is EOL and no longer receiving security updates (or any updates) from the core Python team. 

It's also little used.

Here's the pip installs for websocket-client from PyPI for May 2018:
	
| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |  68.09% |        583,338 |
| 3.6            |  16.99% |        145,548 |
| 3.5            |  12.25% |        104,991 |
| 3.4            |   2.41% |         20,624 |
| 2.6            |   0.12% |          1,012 |
| 3.7            |   0.11% |            918 |
| 3.3            |   0.02% |            192 |
| 3.8            |   0.01% |            105 |
| None           |   0.00% |             15 |
| 3.2            |   0.00% |              3 |
| Total          |         |        856,746 |

Source: `pypinfo --start-date 2018-05-01 --end-date 2018-05-31 --percent --markdown websocket_client pyversion`

Dropping it allows old code to be removed and other code to be updated for modern Python.

Here's a passing build for this PR: https://travis-ci.org/hugovk/websocket-client/builds/417574198