### PR TITLE
Add option to disable sending the Origin header

### DIFF
--- a/websocket/_core.py
+++ b/websocket/_core.py
@@ -201,6 +201,7 @@ class WebSocket(object):
         options: "header" -> custom http header list or dict.
                  "cookie" -> cookie value.
                  "origin" -> custom origin url.
+                             Pass False to send no Origin header.
                  "host"   -> custom host header string.
                  "http_proxy_host" - http proxy host name.
                  "http_proxy_port" - http proxy port. If not set, set to 80.

--- a/websocket/_handshake.py
+++ b/websocket/_handshake.py
@@ -97,7 +97,8 @@ def _get_handshake_headers(resource, host, port, options):
         headers.append("Host: %s" % hostport)
 
     if "origin" in options and options["origin"] is not None:
-        headers.append("Origin: %s" % options["origin"])
+        if options["origin"] is not False:
+            headers.append("Origin: %s" % options["origin"])
     else:
         headers.append("Origin: http://%s" % hostport)
 


### PR DESCRIPTION
I'm writing an OpenStack console client using this library and want the library not to emit an `Origin` header because the console server expects the header not to be present when accessed from a non-browser client (This behavior accords to [RFC6455 &sect;1.3](https://tools.ietf.org/html/rfc6455#section-1.3) where non-browser WebSocket clients are not required to send the `Origin` header during a handshake). But there is currently no option to disable sending the header, and this patch implements it.

I chose `origin=False` option for the purpose because `origin=None` and `origin=''` are already used for other cases: sending the default origin (`"http://host:port"` where host and port are those of the WebSocket endpoint) and the emitting empty Origin header (which is illegal according to RFC6454 though), respectively.
