### PR TITLE
Enable multithreading protection with ping_interval

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -226,7 +226,8 @@ class WebSocketApp(object):
             self.sock = WebSocket(
                 self.get_mask_key, sockopt=sockopt, sslopt=sslopt,
                 fire_cont_frame=self.on_cont_message and True or False,
-                skip_utf8_validation=skip_utf8_validation)
+                skip_utf8_validation=skip_utf8_validation,
+                enable_multithread=True if ping_interval else False)
             self.sock.settimeout(getdefaulttimeout())
             self.sock.connect(
                 self.url, header=self.header, cookie=self.cookie,


### PR DESCRIPTION
If the user sets ping_interval, then threading safety must be enabled with the WebSocket object so network sends do not potentially collide. The ping_interval setting on WebSocketApp causes the app to create a new thread to send websocket ping frames, which (when combined with sending of other websocket messages from other threads) runs the risk of a ping frame and another websocket frame colliding (since python sockets aren't thread safe).