### PR TITLE
reset WebsocketApp.sock

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -159,6 +159,7 @@ class WebSocketApp(object):
         self.keep_running = False
         if self.sock:
             self.sock.close(**kwargs)
+            self.sock = None
 
     def _send_ping(self, interval, event):
         while not event.wait(interval):


### PR DESCRIPTION
consider the following snap
```python
def ws_on_message(ws, message):
    msg = json.loads(message)
    if msg.get("restart"):
        ws.close()

wsapp = websocket.WebSocketApp(url, on_message=ws_on_message, ...)
while True:
    wsapp.run_forever()
    
```
expect restart the connection after receiving restart signal from server.
but  we will  receive exception `WebSocketException("socket is already opened")` because the method `ws.close()` only close `ws.sock.sock.close()` and reset `ws.sock.sock = None` underlying network socket. noting to do with the ws.sock, it will remeber the previous instance that already invalid now.