### PR TITLE
pass proper arguments to method callbacks

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -325,7 +325,7 @@ class WebSocketApp(object):
     def _callback(self, callback, *args):
         if callback:
             try:
-                if inspect.ismethod(callback):
+                if inspect.ismethod(callback) and isinstance(callback.__self__, WebSocketApp):
                     callback(*args)
                 else:
                     callback(self, *args)


### PR DESCRIPTION
There is a regression in 0.49.0 introduced by https://github.com/websocket-client/websocket-client/pull/442 cc @bashlakov. If you have callbacks (`on_open` etc) that are methods on a class, but the class is not a subclass of `WebsocketApp`, it tries to call them with the wrong arguments, and you get an error like this:
```
2018-08-15 14:43:49,328 79988 ERROR WebsockThread:9222 websocket.error(_logging.py:61) error from callback <bound method WebsockReceiverThread._on_open of <WebsockReceiverThread(WebsockThread:9222, started daemon 123145314500608)>>: _on_open() missing 1 required positional argument: 'websock'
```