### PR TITLE
Replace Python 3.7-dev with 3.7 official

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: python
 
-python:
-  - '2.7'
-  - '3.4'
-  - '3.5'
-  - '3.6'
-  - '3.7-dev'
-  - 'pypy'
-  - 'nightly'
+matrix:
+  include:
+    - python: '2.7'
+    - python: '3.4'
+    - python: '3.5'
+    - python: '3.6'
+    - python: '3.7'
+      dist: xenial
+      sudo: true
 
 install:
   - pip install -U pip setuptools wheel


### PR DESCRIPTION
Python 3.7 requires sudo and Xenial as detailed in https://github.com/travis-ci/travis-ci/issues/9815.