### PR TITLE
Fixing none compare bug in run_forever

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -201,7 +201,7 @@ class WebSocketApp(object):
         supress_origin: suppress outputting origin header.
         """
 
-        if not ping_timeout or ping_timeout <= 0:
+        if ping_timeout is not None and (not ping_timeout or ping_timeout <= 0):
             ping_timeout = None
         if ping_timeout and ping_interval and ping_interval <= ping_timeout:
             raise WebSocketException("Ensure ping_interval > ping_timeout")


### PR DESCRIPTION
Fixes https://github.com/websocket-client/websocket-client/issues/466. Ensures ping_timeout is not already `None` before doing a `<= 0` check to make it `None`