### PR TITLE
Fix NoneType bug introduced by #386 fix

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -48,7 +48,7 @@ class Dispatcher:
     def read(self, sock, read_callback, check_callback):
         while self.app.sock.connected:
             r, w, e = select.select(
-            (self.app.sock.sock, ), (), (), self.ping_timeout) # Use a 10 second timeout to avoid to wait forever on close
+            (self.app.sock.sock, ), (), (), self.ping_timeout)
             if r:
                 if not read_callback():
                     break
@@ -282,15 +282,15 @@ class WebSocketApp(object):
                 return True
 
             def check():
-                has_timeout_expired = time.time() - self.last_ping_tm > ping_timeout
-                has_pong_not_arrived_after_last_ping = self.last_pong_tm - self.last_ping_tm < 0
-                has_pong_arrived_too_late = self.last_pong_tm - self.last_ping_tm > ping_timeout
+                if (ping_timeout):
+                    has_timeout_expired = time.time() - self.last_ping_tm > ping_timeout
+                    has_pong_not_arrived_after_last_ping = self.last_pong_tm - self.last_ping_tm < 0
+                    has_pong_arrived_too_late = self.last_pong_tm - self.last_ping_tm > ping_timeout
 
-                if (ping_timeout
-                        and self.last_ping_tm
-                        and has_timeout_expired
-                        and (has_pong_not_arrived_after_last_ping or has_pong_arrived_too_late)):
-                    raise WebSocketTimeoutException("ping/pong timed out")
+                    if (self.last_ping_tm
+                            and has_timeout_expired
+                            and (has_pong_not_arrived_after_last_ping or has_pong_arrived_too_late)):
+                        raise WebSocketTimeoutException("ping/pong timed out")
                 return True
 
             dispatcher.read(self.sock.sock, read, check)


### PR DESCRIPTION
The fix for #386 removed the 10 second ping_timeout default and in doing so introduced a bug in the check function, defined in the run_forever method of WebSocketApp.  As a result of this, failing to explicitly specify a ping_timeout when calling run_forever leads to an "unorderable types: float() > NoneType()" exception.  Refer to the following stack trace:

       >>> traceback.print_tb(terminal_error.__traceback__)
        File "./websocket/_app.py", line 296, in run_forever
          dispatcher.read(self.sock.sock, read, check)
        File "./websocket/_app.py", line 55, in read
          check_callback()
        File "./websocket/_app.py", line 285, in check
          has_timeout_expired = time.time() - self.last_ping_tm > ping_timeout

This change fixes the problem by not checking for a timeout if ping_timeout has not been specified, under the presumption that this is the desired behavior since the 10 second default has been explicitly removed.  It may instead be desirable to default to 10 seconds in the run_forever method's check function (as is done in the create_dispatcher method), if an automatic timeout is always desired.