### PR TITLE
Status return for WebSocketApp.run_forever()

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -199,6 +199,11 @@ class WebSocketApp(object):
         origin: update origin header.
         dispatcher: customize reading data from socket.
         supress_origin: suppress outputting origin header.
+
+        Returns
+        -------
+        False if caught KeyboardInterrupt
+        True if other exception was raised during a loop
         """
 
         if ping_timeout is not None and (not ping_timeout or ping_timeout <= 0):
@@ -300,6 +305,7 @@ class WebSocketApp(object):
                 # propagate SystemExit further
                 raise
             teardown()
+            return not isinstance(e, KeyboardInterrupt)
 
     def create_dispatcher(self, ping_timeout):
         timeout = ping_timeout or 10


### PR DESCRIPTION
`WebSocketApp.run_forever()` returns `True` on any exception and `False` on `KeyboardInterrupt`.  
The purpose of this commit is to give a straightforward way to rerun `WebSocketApp` if it died unexpectedly:

```python
while True:
    ws = websocket.WebSocketApp(...)
    if not ws.run_forever():
        print("Bye")
        break
    else:
        sleep(5)
        print("Reconnecting...")
```