### PR TITLE
fix callback

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -340,7 +340,7 @@ class WebSocketApp(object):
         if callback:
             try:
                 if inspect.ismethod(callback):
-                    callback(*args)
+                    callback(self, *args)
                 else:
                     callback(self, *args)
 


### PR DESCRIPTION
when my iqoptionapi use last version websocket-client get this error
```
error from callback <bound method WebsocketClient.on_message of <iqoptionapi.ws.client.WebsocketClient object at 0x7f174fdb5e48>>: on_message() missing 1 required positional argument: 'message'
  File "/usr/lib/python3.7/site-packages/websocket/_app.py", line 343, in _callback
   callback(*args)
```
change the code 
callback(*args)->callback(self, *args)
can fix my problem