### PR TITLE
Manually assigning WebSocket-Version

### DIFF
--- a/websocket/_handshake.py
+++ b/websocket/_handshake.py
@@ -115,8 +115,16 @@ def _get_handshake_headers(resource, host, port, options):
             headers.append("Origin: http://%s" % hostport)
 
     key = _create_sec_websocket_key()
-    headers.append("Sec-WebSocket-Key: %s" % key)
-    headers.append("Sec-WebSocket-Version: %s" % VERSION)
+    
+    # Append Sec-WebSocket-Key & Sec-WebSocket-Version if not manually specified
+    if not 'header' in options or 'Sec-WebSocket-Key' not in options['header']:
+        key = _create_sec_websocket_key()
+        headers.append("Sec-WebSocket-Key: %s" % key)
+    else:
+        key = options['header']['Sec-WebSocket-Key']
+
+    if not 'header' in options or 'Sec-WebSocket-Version' not in options['header']:
+        headers.append("Sec-WebSocket-Version: %s" % VERSION)
 
     subprotocols = options.get("subprotocols")
     if subprotocols:


### PR DESCRIPTION
When manually assigning `Sec-WebSocket-Key` & `Sec-WebSocket-Version`, websocket-client would raise:

    WebSocketException("Invalid WebSocket Header")

Because the key for instance, would be inserted twice.
The best way to get around this in the long run, would be to refrain from using lists as the header builder, since keys can't occur twice anyway. Thus, just creating the automated headers first, and then iterating over whatever the user inputs - would effectively replace any default headers automatically, without needing to parse "if host in options['headers']" etc. Just iterate over the headers given, replace the default ones and bam, profit.

tl;dr:
---
It's dangerous to assume we can append headers, if we later iterate over custom headers given by the user. Making for instance `version` be defined twice. Causing all kinds of ruckus.