### PR TITLE
adding ability to call instance method as callback

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -339,7 +339,7 @@ class WebSocketApp(object):
     def _callback(self, callback, *args):
         if callback:
             try:
-                if inspect.ismethod(callback):
+                if inspect.ismethod(callback) and isinstance(callback.__self__, WebSocketApp):
                     callback(*args)
                 else:
                     callback(self, *args)


### PR DESCRIPTION
If I understand correctly, when someone inherits from WebSocketApp, and uses an instance method as a callback there is no reason to pass 'self' again to the callback.
but if someone uses an instance method of some other class the callback will fail with error:
on_open() missing 1 required positional argument: 'ws'
or similar

My fix allows passing 'self' only once when callback is an instance method of WebSocketApp, but won't fail when the callback is an instance of another class

I saw it was already part of the code once :
https://github.com/websocket-client/websocket-client/commit/ae589495b75162703ab4fe1f8712f50d22b12d4e