### PR TITLE
Nonblocking websocket recv

### DIFF
--- a/websocket/_socket.py
+++ b/websocket/_socket.py
@@ -24,6 +24,7 @@ import socket
 import six
 import sys
 import errno
+import select
 from time import sleep
 
 from ._exceptions import *
@@ -85,7 +86,7 @@ def recv(sock, bufsize):
         except socket.error, e:
             err = e.args[0]
             if err == errno.EAGAIN or err == errno.EWOULDBLOCK:
-                sleep(0.1)
+                select.select([sock], [], [])
                 continue
             message = extract_err_message(e)
             raise WebSocketTimeoutException(message)

--- a/websocket/_socket.py
+++ b/websocket/_socket.py
@@ -25,7 +25,6 @@ import six
 import sys
 import errno
 import select
-from time import sleep
 
 from ._exceptions import *
 from ._ssl_compat import *


### PR DESCRIPTION
I'm experiencing quite a few issues because of this, hence the PR :)

When using non-blocking websockets the OS might throw EAGAIN or EWOULDBLOCK.
This is not really an error but rather a "please come back and retry later, buffer is still empty"
According to this https://stackoverflow.com/questions/11647046/non-blocking-socket-error-is-always
the function which reads from a non-blocking socket buffer should be handled as per this PR.