### PR TITLE
Ensure that "timeout" is passed down, when calling WebSocket.connect()

### DIFF
--- a/websocket/_core.py
+++ b/websocket/_core.py
@@ -216,6 +216,9 @@ class WebSocket(object):
                  "socket" - pre-initialized stream socket.
 
         """
+        # FIXME: "subprotocols" are getting lost, not passed down
+        # FIXME: "header", "cookie", "origin" and "host" too
+        self.sock_opt.timeout = options.get('timeout', self.sock_opt.timeout)
         self.sock, addrs = connect(url, self.sock_opt, proxy_info(**options),
                                    options.pop('socket', None))
 


### PR DESCRIPTION
Note: that still leaves "subprotocols", "header", "cookie", "origin" and "host" values in a bugged state (they are NOT passed down).