### PR TITLE
Ensure callbacks are called with proper arguments.

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -339,7 +339,8 @@ class WebSocketApp(object):
     def _callback(self, callback, *args):
         if callback:
             try:
-                if inspect.ismethod(callback):
+                if (inspect.ismethod(callback)
+                and isinstance(callback.__self__, WebSocketApp)):
                     callback(*args)
                 else:
                     callback(self, *args)


### PR DESCRIPTION
Latest related commit is efcf31b30122e05701fb3f696b029baf8faa6d8e.
Related issues are #471.

Problem: if callback is a bound method of an object, _app code **wrongly** assumes the object is a subclass of WebSocketApp, and does NOT pass the "ws" parameter, thus breaking compatibility with existing code.

This fix allows all 3 use cases: WebSocketApp subclasses, unrelated objects and unbound functions.

```python3
def unbound_func(ws):
    print("WS:", ws)

class SomeSub(WebSocketApp):
    def my_on_open(self):
        print("WS:", self)

class SomeObject:
    def my_on_open(self, ws):
        print("WS:", ws)
```

Without this fix (or by reverting the whole `ismethod` thing completely), only one or two of those will work.