### PR TITLE
Retry connect on "Interrupted system call"

### DIFF
--- a/websocket/_http.py
+++ b/websocket/_http.py
@@ -166,26 +166,32 @@ def _open_socket(addrinfo_list, sockopt, timeout):
             sock.setsockopt(*opts)
 
         address = addrinfo[4]
-        try:
-            sock.connect(address)
-            err = None
-        except ProxyConnectionError as error:
-            err = WebSocketProxyException(str(error))
-            err.remote_ip = str(address[0])
-            continue
-        except socket.error as error:
-            error.remote_ip = str(address[0])
+        err = None
+        while not err:
             try:
-                eConnRefused = (errno.ECONNREFUSED, errno.WSAECONNREFUSED)
-            except:
-                eConnRefused = (errno.ECONNREFUSED, )
-            if error.errno in eConnRefused:
-                err = error
+                sock.connect(address)
+            except ProxyConnectionError as error:
+                err = WebSocketProxyException(str(error))
+                err.remote_ip = str(address[0])
                 continue
+            except socket.error as error:
+                error.remote_ip = str(address[0])
+                try:
+                    eConnRefused = (errno.ECONNREFUSED, errno.WSAECONNREFUSED)
+                except:
+                    eConnRefused = (errno.ECONNREFUSED, )
+                if error.errno == errno.EINTR:
+                    continue
+                elif error.errno in eConnRefused:
+                    err = error
+                    continue
+                else:
+                    raise error
             else:
-                raise error
+                break
         else:
-            break
+            continue
+        break
     else:
         raise err
 


### PR DESCRIPTION
When connecting to a socket, EINTR ("Interrupted system call") may be
raised if the application receives a signal at the same time. Prior to
Python 3.5, applications has to handle this themselves by retrying the
connection. For more details, see https://www.python.org/dev/peps/pep-0475/

Fixes #527