### PR TITLE
Fix `WebSocket.close` in multi-threaded environments

### DIFF
--- a/websocket/_core.py
+++ b/websocket/_core.py
@@ -425,7 +425,7 @@ class WebSocket(object):
             except:
                 pass
 
-        self.shutdown()
+            self.shutdown()
 
     def abort(self):
         """


### PR DESCRIPTION
In multi-threaded environment where the `WebsocketApp` lives in another thread
than the main thread, the main thread might call `WebsocketApp.close` which
will sends the closing message to the backend and then wait for the answer.

This will likely makes the following loop
https://github.com/websocket-client/websocket-client/blob/master/websocket/_app.py#L49
to ends which will calls
https://github.com/websocket-client/websocket-client/blob/master/websocket/_app.py#L235.

The second call will happened in the `WebsocketApp` thread and as the socket
is already marked as not connected anymore, the second thread will jump
directly into the `WebSocket.shutdown` method which will abruptly close the
socket, stopping all in-progress sending and making the first call to
`WebSocket.close` to crash as `self.sock` is replaces by None.