### PR TITLE
_handshake: hasattr checks on six before accessing the values

### DIFF
--- a/websocket/_handshake.py
+++ b/websocket/_handshake.py
@@ -31,13 +31,13 @@ from ._http import *
 from ._logging import *
 from ._socket import *
 
-if six.PY3:
+if hasattr(six, 'PY3') and six.PY3:
     from base64 import encodebytes as base64encode
 else:
     from base64 import encodestring as base64encode
 
-if six.PY3:
-    if six.PY34:
+if hasattr(six, 'PY3') and six.PY3:
+    if hasattr(six, 'PY34') and six.PY34:
         from http import client as HTTPStatus
     else:
         from http import HTTPStatus


### PR DESCRIPTION
I had to make these changes to get websocket-client working in a kivy app with python3 where six did not have the PY34 attribute.