### PR TITLE
Don't retry sockets with timeout set to 0

### DIFF
--- a/websocket/_socket.py
+++ b/websocket/_socket.py
@@ -96,7 +96,10 @@ def recv(sock, bufsize):
             return sock.recv(bufsize)
 
     try:
-        bytes_ = _recv()
+        if sock.gettimeout() == 0:
+            bytes_ = sock.recv(bufsize)
+        else:
+            bytes_ = _recv()
     except socket.timeout as e:
         message = extract_err_message(e)
         raise WebSocketTimeoutException(message)
@@ -148,7 +151,10 @@ def send(sock, data):
             return sock.send(data)
 
     try:
-        return _send()
+        if sock.gettimeout() == 0:
+            return sock.send(data)
+        else:
+            return _send()
     except socket.timeout as e:
         message = extract_err_message(e)
         raise WebSocketTimeoutException(message)

--- a/websocket/tests/test_websocket.py
+++ b/websocket/tests/test_websocket.py
@@ -55,6 +55,9 @@ class SockMock(object):
     def add_packet(self, data):
         self.data.append(data)
 
+    def gettimeout(self):
+        return None
+
     def recv(self, bufsize):
         if self.data:
             e = self.data.pop(0)


### PR DESCRIPTION
For non-blocking sockets with the timeout set to 0, the select call in
_recv and _send will return immediately without the socket being ready.
This causes _recv to return None, which makes recv close the connection.
Since a select with a timeout of 0 right after recv/send is pointless,
just skip _recv and _send when timeout is 0.

As for the handling of SSLWantReadError, SSLWantWriteError, EAGAIN and
EWOULDBLOCK in _recv/_send, websocket-client can't handle these without
blocking. Since applications which has timeout set to 0 don't want
websocket-client to block them, they have to handle those errors
themselves.

Fixes #535