### PR TITLE
v should be checked for emptry string before splitting it

### DIFF
--- a/websocket/_url.py
+++ b/websocket/_url.py
@@ -103,7 +103,8 @@ def _is_address_in_network(ip, net):
 def _is_no_proxy_host(hostname, no_proxy):
     if not no_proxy:
         v = os.environ.get("no_proxy", "").replace(" ", "")
-        no_proxy = v.split(",")
+        if v:
+            no_proxy = v.split(",")
     if not no_proxy:
         no_proxy = DEFAULT_NO_PROXY_HOST
 


### PR DESCRIPTION
when name 'v' has empty string on splitting this empty string we get a list with empty string like ['']
This will make the next if statement "if not no_proxy:" false.
This is leading to a bug where a connection initiated from a localhost / 127.0.0.1 will not be considered as no_proxy type of connection.
Leading to an exception ValueError("scheme %s is invalid" % scheme) with the scheme value set to http from parse_url() function