### PR TITLE
fix the compatible issue with gevent+dnspython

### DIFF
--- a/websocket/_http.py
+++ b/websocket/_http.py
@@ -140,7 +140,7 @@ def _get_addrinfo_list(hostname, port, is_secure, proxy):
     try:
         if not phost:
             addrinfo_list = socket.getaddrinfo(
-                hostname, port, 0, 0, socket.SOL_TCP)
+                hostname, port, 0, socket.SOCK_STREAM, socket.SOL_TCP)
             return addrinfo_list, False, None
         else:
             pport = pport and pport or 80


### PR DESCRIPTION
When using gevent.patch_all() and dnspython as resolver,in some special case will cause `socket.error: [Errno 22] Invalid argument`

Here is the snippet with python2 and gevent==1.4.0 dnspython==1.16.0 

```python
import gevent

gevent.config.resolver = 'dnspython'

from gevent import monkey
monkey.patch_all()

from websocket import create_connection

ws = create_connection('wss://market-api.rbtc.io/sub')
```

In that case, if you don't force the socket type to `socket.SOCK_STREAM`, `socket.getaddrinfo()` will return both `socket.SOCK_STREAM` and `socket.SOCK_DGRAM`(UDP). But `DEFAULT_SOCKET_OPTION` is tcp only, so `sock.setsockopt()` will raise the `socket.error: [Errno 22] Invalid argument`
