### PR TITLE
Expose http connection header to user

### DIFF
--- a/websocket/_handshake.py
+++ b/websocket/_handshake.py
@@ -124,7 +124,7 @@ def _get_handshake_headers(resource, host, port, options):
     if not 'header' in options or 'Sec-WebSocket-Version' not in options['header']:
         headers.append("Sec-WebSocket-Version: %s" % VERSION)
 
-    if not 'connection' in options:
+    if not 'connection' in options or options['connection'] is None:
         headers.append('Connection: upgrade')
     else:
         headers.append(options['connection'])

--- a/websocket/_handshake.py
+++ b/websocket/_handshake.py
@@ -101,7 +101,6 @@ def _get_handshake_headers(resource, host, port, options):
         hostport = _pack_hostname(host)
     else:
         hostport = "%s:%d" % (_pack_hostname(host), port)
-    
     if "host" in options and options["host"] is not None:
         headers.append("Host: %s" % options["host"])
     else:

--- a/websocket/_handshake.py
+++ b/websocket/_handshake.py
@@ -95,14 +95,13 @@ def _pack_hostname(hostname):
 def _get_handshake_headers(resource, host, port, options):
     headers = [
         "GET %s HTTP/1.1" % resource,
-        "Upgrade: websocket",
-        "Connection: Upgrade"
+        "Upgrade: websocket"
     ]
     if port == 80 or port == 443:
         hostport = _pack_hostname(host)
     else:
         hostport = "%s:%d" % (_pack_hostname(host), port)
-
+    
     if "host" in options and options["host"] is not None:
         headers.append("Host: %s" % options["host"])
     else:
@@ -125,6 +124,11 @@ def _get_handshake_headers(resource, host, port, options):
 
     if not 'header' in options or 'Sec-WebSocket-Version' not in options['header']:
         headers.append("Sec-WebSocket-Version: %s" % VERSION)
+
+    if not 'connection' in options:
+        headers.append('Connection: upgrade')
+    else:
+        headers.append(options['connection'])
 
     subprotocols = options.get("subprotocols")
     if subprotocols:


### PR DESCRIPTION
In [HTTP/1.1 protocol](https://tools.ietf.org/html/rfc2616#section-4.2), message headers are comma separated values. For example: **Connection: keep-alive, upgrade**.
I've exposed "connection" message header to end users, by allowing them to pass "connection" in the options. Passed in value overrides the default value inside _handshake.py. Example usage:
`ws = websocket.WebSocket()`
`ws.connect("ws://192.168.1.3/.../",connection = 'Connection: keep-alive, Upgrade')`