### PR TITLE
Replace unsafe six.PY3 with PY2 to fix for Python 4

### DIFF
--- a/bin/wsdump.py
+++ b/bin/wsdump.py
@@ -75,10 +75,10 @@ def parse_args():
 class RawInput:
 
     def raw_input(self, prompt):
-        if six.PY3:
-            line = input(prompt)
-        else:
+        if six.PY2:
             line = raw_input(prompt)
+        else:
+            line = input(prompt)
 
         if ENCODING and ENCODING != "utf-8" and not isinstance(line, six.text_type):
             line = line.decode(ENCODING).encode("utf-8")
@@ -160,7 +160,7 @@ def main():
         while True:
             opcode, data = recv()
             msg = None
-            if six.PY3 and opcode == websocket.ABNF.OPCODE_TEXT and isinstance(data, bytes):
+            if not six.PY2 and opcode == websocket.ABNF.OPCODE_TEXT and isinstance(data, bytes):
                 data = str(data, "utf-8")
             if not args.verbose and opcode in OPCODE_DATA:
                 msg = data

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ NAME = "websocket_client"
 install_requires = ["six"]
 tests_require = []
 
-if sys.version_info[0] == 2 and sys.version_info[1] < 7:
+if sys.version_info < (2, 7):
         tests_require.append('unittest2==0.8.0')
 
 insecure_pythons = '2.6, ' + ', '.join("2.7.{pv}".format(pv=pv) for pv in range(10))

--- a/websocket/_abnf.py
+++ b/websocket/_abnf.py
@@ -30,10 +30,10 @@ from ._utils import validate_utf8
 from threading import Lock
 
 try:
-    if six.PY3:
-        import numpy
-    else:
+    if six.PY2:
         numpy = None
+    else:
+        import numpy
 except ImportError:
     numpy = None
 
@@ -50,10 +50,10 @@ except ImportError:
         for i in range(len(_d)):
             _d[i] ^= _m[i % 4]
 
-        if six.PY3:
-            return _d.tobytes()
-        else:
+        if six.PY2:
             return _d.tostring()
+        else:
+            return _d.tobytes()
 
 
 __all__ = [

--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -283,7 +283,7 @@ class WebSocketApp(object):
                                    frame.data, frame.fin)
                 else:
                     data = frame.data
-                    if six.PY3 and op_code == ABNF.OPCODE_TEXT:
+                    if not six.PY2 and op_code == ABNF.OPCODE_TEXT:
                         data = data.decode("utf-8")
                     self._callback(self.on_data, data, frame.opcode, True)
                     self._callback(self.on_message, data)

--- a/websocket/_core.py
+++ b/websocket/_core.py
@@ -311,7 +311,7 @@ class WebSocket(object):
         """
         with self.readlock:
             opcode, data = self.recv_data()
-        if six.PY3 and opcode == ABNF.OPCODE_TEXT:
+        if not six.PY2 and opcode == ABNF.OPCODE_TEXT:
             return data.decode("utf-8")
         elif opcode == ABNF.OPCODE_TEXT or opcode == ABNF.OPCODE_BINARY:
             return data

--- a/websocket/_handshake.py
+++ b/websocket/_handshake.py
@@ -31,18 +31,18 @@ from ._http import *
 from ._logging import *
 from ._socket import *
 
-if six.PY3:
-    from base64 import encodebytes as base64encode
-else:
+if six.PY2:
     from base64 import encodestring as base64encode
+else:
+    from base64 import encodebytes as base64encode
 
-if six.PY3:
+if six.PY2:
+    import httplib as HTTPStatus
+else:
     if six.PY34:
         from http import client as HTTPStatus
     else:
         from http import HTTPStatus
-else:
-    import httplib as HTTPStatus
 
 __all__ = ["handshake_response", "handshake", "SUPPORTED_REDIRECT_STATUSES"]
 

--- a/websocket/_http.py
+++ b/websocket/_http.py
@@ -32,10 +32,10 @@ from ._socket import*
 from ._ssl_compat import *
 from ._url import *
 
-if six.PY3:
-    from base64 import encodebytes as base64encode
-else:
+if six.PY2:
     from base64 import encodestring as base64encode
+else:
+    from base64 import encodebytes as base64encode
 
 __all__ = ["proxy_info", "connect", "read_headers"]
 

--- a/websocket/tests/test_websocket.py
+++ b/websocket/tests/test_websocket.py
@@ -18,10 +18,10 @@ from websocket._http import read_headers
 from websocket._url import get_proxy_info, parse_url
 from websocket._utils import validate_utf8
 
-if six.PY3:
-    from base64 import decodebytes as base64decode
-else:
+if six.PY2:
     from base64 import decodestring as base64decode
+else:
+    from base64 import decodebytes as base64decode
 
 if sys.version_info[0] == 2 and sys.version_info[1] < 7:
     import unittest2 as unittest

--- a/websocket/tests/test_websocket.py
+++ b/websocket/tests/test_websocket.py
@@ -23,7 +23,7 @@ if six.PY2:
 else:
     from base64 import decodebytes as base64decode
 
-if sys.version_info[0] == 2 and sys.version_info[1] < 7:
+if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
     import unittest
@@ -154,7 +154,7 @@ class WebSocketTest(unittest.TestCase):
 
         self.assertRaises(ValueError, parse_url, "http://www.example.com/r")
 
-        if sys.version_info[0] == 2 and sys.version_info[1] < 7:
+        if sys.version_info < (2, 7):
             return
 
         p = parse_url("ws://[2a03:4000:123:83::3]/r")


### PR DESCRIPTION
We don't yet know if 3.10 or 4.0 will follow Python 3.9, but whichever it is, it will probably happen in [2020 when Python 3.9 reaches beta](https://www.python.org/dev/peps/pep-0596/#schedule) and work begins on Python 3.9+1.

There's some code which uses `six.PY3`:

```python
if six.PY3:
    print("Python 3+ code")
else:
    print("Python 2 code")
```

Where in six:

```python
PY3 = sys.version_info[0] == 3
```

When run on Python 4, this will run the Python 2 code! Instead, flip the check to `PY2`.


Found using https://github.com/asottile/flake8-2020:
```console
$ pip install -U flake8-2020
...
$ flake8 --select YTT
./websocket/_http.py:35:4: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./websocket/_handshake.py:34:4: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./websocket/_handshake.py:39:4: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./websocket/_app.py:286:24: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./websocket/_abnf.py:33:8: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./websocket/_abnf.py:53:12: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./websocket/_core.py:314:12: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./websocket/tests/test_websocket.py:21:4: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./bin/wsdump.py:78:12: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
./bin/wsdump.py:163:16: YTT202 `six.PY3` referenced (python4), use `not six.PY2`
```
