### PR TITLE
Add compressed text messages in wsdump.py

### DIFF
--- a/bin/wsdump.py
+++ b/bin/wsdump.py
@@ -6,6 +6,8 @@ import sys
 import threading
 import time
 import ssl
+import gzip
+import zlib
 
 import six
 from six.moves.urllib.parse import urlparse
@@ -162,10 +164,28 @@ def main():
             msg = None
             if six.PY3 and opcode == websocket.ABNF.OPCODE_TEXT and isinstance(data, bytes):
                 data = str(data, "utf-8")
-            if not args.verbose and opcode in OPCODE_DATA:
-                msg = data
-            elif args.verbose:
+            if isinstance(data, bytes) and len(data)>2 and data[:2] == b'\037\213':  # gzip magick
+                try:
+                    data = "[gzip] " + str(gzip.decompress(data), "utf-8")
+                except:
+                    pass
+            elif isinstance(data, bytes):
+                try:
+                    decomp = zlib.decompressobj(
+                            -zlib.MAX_WBITS
+                    )
+                    data = decomp.decompress(data)
+                    data = "[zlib] " + str(data + decomp.flush(), "utf-8")
+                except:
+                    pass
+
+            if isinstance(data, bytes):
+                data = repr(data)
+
+            if args.verbose:
                 msg = "%s: %s" % (websocket.ABNF.OPCODE_MAP.get(opcode), data)
+            else:
+                msg = data
 
             if msg is not None:
                 if args.timings:

--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -339,10 +339,7 @@ class WebSocketApp(object):
     def _callback(self, callback, *args):
         if callback:
             try:
-                if inspect.ismethod(callback):
-                    callback(*args)
-                else:
-                    callback(self, *args)
+                callback(self, *args)
 
             except Exception as e:
                 _logging.error("error from callback {}: {}".format(callback, e))


### PR DESCRIPTION
This commit adds support for **gzip** and **zlib compressed text messages**.

Before this commit, `wsdump.py` was failing trying to concatenate `str` and `bytes`:
```
Press Ctrl+C to quit
> ping
> Exception in thread Thread-1:
Traceback (most recent call last):
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/threading.py", line 926, in _bootstrap_inner
    self.run()
  File "/opt/local/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/admin/src/websocket-client/bin/wsdump.py", line 174, in recv_ws
    console.write(msg)
  File "/Users/admin/src/websocket-client/bin/wsdump.py", line 96, in write
    sys.stdout.write("\033[34m< " + data + "\033[39m")
TypeError: can only concatenate str (not "bytes") to str
```

After this commit, it properly decompresses gzip or zlib data before printing to a console:
```
Press Ctrl+C to quit
> ping
< [zlib] pong
```