### PR TITLE
Create dummy `ssl` object

### DIFF
--- a/websocket/_ssl_compat.py
+++ b/websocket/_ssl_compat.py
@@ -49,4 +49,6 @@ except ImportError:
     class SSLWantWriteError(Exception):
         pass
 
+    ssl = lambda: None
+
     HAVE_SSL = False


### PR DESCRIPTION
There is currently a problem with compat for non-SSL support. Module `_ssl_compat` already tries to import `ssl` module, catch error if it occurs and tell main program that SSL is not available. However, because `ssl` object is defined in `__all__`, Python expects to be existing. This is why import of `_ssl_compat` will fail if SSL is not available, even if it will not be used.

This PR adds dummy`ssl` object which should fix the error with undefined `ssl` module.

---

This is the error:

```
    import websocket
  File "/lib/python3.7/site-packages/websocket/__init__.py", line 23, in <module>
    from ._app import WebSocketApp
  File "/lib/python3.7/site-packages/websocket/_app.py", line 36, in <module>
    from ._core import WebSocket, getdefaulttimeout
  File "/lib/python3.7/site-packages/websocket/_core.py", line 34, in <module>
    from ._handshake import *
  File "/lib/python3.7/site-packages/websocket/_handshake.py", line 30, in <module>
    from ._http import *
  File "/lib/python3.7/site-packages/websocket/_http.py", line 31, in <module>
    from ._socket import*
  File "/lib/python3.7/site-packages/websocket/_socket.py", line 30, in <module>
    from ._ssl_compat import *
AttributeError: module 'websocket._ssl_compat' has no attribute 'ssl'
```