### PR TITLE
Fixed typo

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -54,7 +54,7 @@ class Dispatcher:
                     break
             check_callback()
 
-class SSLDispacther:
+class SSLDispatcher:
     def __init__(self, app, ping_timeout):
         self.app  = app
         self.ping_timeout = ping_timeout
@@ -314,7 +314,7 @@ class WebSocketApp(object):
     def create_dispatcher(self, ping_timeout):
         timeout = ping_timeout or 10
         if self.sock.is_ssl():
-            return SSLDispacther(self, timeout)
+            return SSLDispatcher(self, timeout)
 
         return Dispatcher(self, timeout)
 


### PR DESCRIPTION
Class name "SSLDispacther" had a typo, should be "SSLDispatcher". Fixed class definition, and instance creation (in create_dispatcher). I haven't checked other files though.