### PR TITLE
avoid calling repr(data) if tracing is not enabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ dist
 
 .cache/
 compliance/reports/
+.eggs
+.vscode

--- a/websocket/_core.py
+++ b/websocket/_core.py
@@ -271,7 +271,8 @@ class WebSocket(object):
             frame.get_mask_key = self.get_mask_key
         data = frame.format()
         length = len(data)
-        trace("send: " + repr(data))
+        if (isEnabledForTrace()):
+            trace("send: " + repr(data))
 
         with self.lock:
             while data:

--- a/websocket/_logging.py
+++ b/websocket/_logging.py
@@ -34,7 +34,7 @@ _logger.addHandler(NullHandler())
 _traceEnabled = False
 
 __all__ = ["enableTrace", "dump", "error", "warning", "debug", "trace",
-           "isEnabledForError", "isEnabledForDebug"]
+           "isEnabledForError", "isEnabledForDebug", "isEnabledForTrace"]
 
 
 def enableTrace(traceable, handler = logging.StreamHandler()):
@@ -48,7 +48,6 @@ def enableTrace(traceable, handler = logging.StreamHandler()):
     if traceable:
         _logger.addHandler(handler)
         _logger.setLevel(logging.DEBUG)
-
 
 def dump(title, message):
     if _traceEnabled:
@@ -80,3 +79,6 @@ def isEnabledForError():
 
 def isEnabledForDebug():
     return _logger.isEnabledFor(logging.DEBUG)
+
+def isEnabledForTrace():
+    return _traceEnabled


### PR DESCRIPTION
for large data payloads the line 
```python
trace("send: " + repr(data))
```
can take a long time to complete (specifically the ```repr(data)``` part).
If tracing is not enabled, the preparation of the **repr** is not needed

I added a condition to only call this line if tracing is enabled.