### PR TITLE
Fix getting 400 bad request with long proxy authorization string

### DIFF
--- a/websocket/_http.py
+++ b/websocket/_http.py
@@ -276,7 +276,7 @@ def _tunnel(sock, host, port, auth):
         auth_str = auth[0]
         if auth[1]:
             auth_str += ":" + auth[1]
-        encoded_str = base64encode(auth_str.encode()).strip().decode()
+        encoded_str = base64encode(auth_str.encode()).strip().decode().replace('\n', '')
         connect_header += "Proxy-Authorization: Basic %s\r\n" % encoded_str
     connect_header += "\r\n"
     dump("request header", connect_header)


### PR DESCRIPTION
Previously passing a long username of password to proxy authorization will cause response 400 Bad Request from proxy server. This commit fix the problem.