### PR TITLE
wsdump: Fix --headers option

### DIFF
--- a/bin/wsdump.py
+++ b/bin/wsdump.py
@@ -130,7 +130,7 @@ def main():
     if args.nocert:
         opts = {"cert_reqs": ssl.CERT_NONE, "check_hostname": False}
     if args.headers:
-        options['header'] = map(str.strip, args.headers.split(','))
+        options['header'] = list(map(str.strip, args.headers.split(',')))
     ws = websocket.create_connection(args.url, sslopt=opts, **options)
     if args.raw:
         console = NonInteractive()


### PR DESCRIPTION
Since https://github.com/websocket-client/websocket-client/pull/506
changes the way that options['header'] is used, it breaks --headers
option of wsdump command because wsdump command uses a map object
instead of a list here, which can only be used once. Therefore, after
the first use with 'not in' operator, it becomes empty and no headers
specified by the user are sent.

To fix it, simply convert the map object into a list, so it can be use
multiple times.