### PR TITLE
Fix typo in connection upgrade header.

### DIFF
--- a/websocket/_handshake.py
+++ b/websocket/_handshake.py
@@ -127,7 +127,7 @@ def _get_handshake_headers(resource, host, port, options):
         headers.append("Sec-WebSocket-Version: %s" % VERSION)
 
     if not 'connection' in options or options['connection'] is None:
-        headers.append('Connection: upgrade')
+        headers.append('Connection: Upgrade')
     else:
         headers.append(options['connection'])
 


### PR DESCRIPTION
See https://tools.ietf.org/html/rfc2817#section-3. Typo was introduced in commit 0598ef1a7a9d72670bf592439f1899412e790989.