### PR TITLE
Add is_opened() function in WebSocketApp class

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -312,6 +312,9 @@ class WebSocketApp(object):
             teardown()
             return not isinstance(e, KeyboardInterrupt)
 
+    def is_opened(self):
+        return self.sock is not None
+
     def create_dispatcher(self, ping_timeout):
         timeout = ping_timeout or 10
         if self.sock.is_ssl():


### PR DESCRIPTION
As user sometime we want to know if the WebSocket his still open with the WebSocketApp class, used in that way could be intuitive:
```Python
import websocket

ws = websocket.WebSocketApp("ws://foo.com")
ws.run_forever()
if ws.is_opened():
    do_something()
```