### PR TITLE
Add support for permitting additional values in the headers

### DIFF
--- a/websocket/_handshake.py
+++ b/websocket/_handshake.py
@@ -178,8 +178,8 @@ def _validate(headers, key, subprotocols):
         r = headers.get(k, None)
         if not r:
             return False, None
-        r = r.lower()
-        if v != r:
+        r = [x.strip().lower() for x in r.split(',')]
+        if v not in r:
             return False, None
 
     if subprotocols:


### PR DESCRIPTION
This pull request resolves #626 by allowing additional values (such as "keep-alive") to exist in the headers.