### PR TITLE
Added documentation for using Unix Domain Sockets and made corresponding changes to wsdump.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -151,6 +151,21 @@ You can also write your own class for the connection, if you want to handle the 
     ws = create_connection("ws://echo.websocket.org/",
                             sockopt=((socket.IPPROTO_TCP, socket.TCP_NODELAY, 1),), class_=MyWebSocket)
 
+Using Unix Domain Sockets
+---------------------------
+You can also connect to a WebSocket server hosted on a unix domain socket. Just use the `socket` option to setup
+your socket and you are good to go!
+
+.. code:: python
+
+    import socket
+    from websocket import create_connection
+    my_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    my_socket.connect("/path/to/my/unix.socket")
+    
+    ws = create_connection("ws://localhost/", # Dummy URL
+                            socket = my_socket,
+                            sockopt=((socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),))
 
 FAQ
 ===

--- a/bin/wsdump.py
+++ b/bin/wsdump.py
@@ -48,7 +48,7 @@ class VAction(argparse.Action):
 def parse_args():
     parser = argparse.ArgumentParser(description="WebSocket Simple Dump Tool")
     parser.add_argument("url", metavar="ws_url",
-                        help="websocket url. ex. ws://echo.websocket.org/")
+                        help="websocket url. ex. ws://echo.websocket.org/ or a valid Unix Path (used in tandem with --unix-socket)")
     parser.add_argument("-p", "--proxy",
                         help="proxy url. ex. http://127.0.0.1:8080")
     parser.add_argument("-v", "--verbose", default=0, nargs='?', action=VAction,


### PR DESCRIPTION
Issue reference: #631 

Adds a new option to `wsdump.py` called `--unix-socket`. This basically connects to the unix domain socket based websocket server. "URL" is just a valid Unix path.

Eg usage:

```
$ ./wsdump.py /path/to/unix.socket --unix-socket
> hello
< hello
```