### PR TITLE
Add venv / PyCharm directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,10 @@ dist
 compliance/reports/
 .eggs
 .vscode
+
+# venv
+.venv/
+.env/
+
+# PyCharm
+.idea/


### PR DESCRIPTION
This pull request adds a few common directories to exclude from Git. 