### PR TITLE
Simplified cookie sorting to fix comparison problem between SimpleCookies

### DIFF
--- a/websocket/_cookiejar.py
+++ b/websocket/_cookiejar.py
@@ -48,5 +48,5 @@ class SimpleCookieJar(object):
             if host.endswith(domain) or host == domain[1:]:
                 cookies.append(self.jar.get(domain))
 
-        return "; ".join(filter(None, ["%s=%s" % (k, v.value) for cookie in filter(None, sorted(cookies)) for k, v in
-                                       sorted(cookie.items())]))
+        return "; ".join(filter(None, sorted(["%s=%s" % (k, v.value) for cookie in filter(None, cookies) for k, v in
+                                       cookie.items()])))


### PR DESCRIPTION
Simplified sorting of cookies by sorting by the final string representation, this fixes https://github.com/websocket-client/websocket-client/issues/614.