### PR TITLE
Add shebang

### DIFF
--- a/bin/wsdump.py
+++ b/bin/wsdump.py
@@ -1,6 +1,4 @@
-"""
-
-"""
+#!/usr/bin/env python3
 
 """
 websocket - WebSocket client library for Python


### PR DESCRIPTION
**1. What is the problem with the current code**

Installing it (e.g. on archlinux) places `bin/wsdump.py` under `/usr/bin/wsdump.py`. Running `wsdump.py` directly executes that script. As there is no shebang, the system will use a shell interpretor (I think) to execute it. This results in weird behavior (e.g. calling the program `import` many times, that create something like screenshots)...

2. How your changes make it better

Add a shebang to let the system know, that this must be executed with python.

3. Provide some example code that can allow someone else to recreate the problem with the current code and test your solution (if possible to recreate).

```bash
$ wsdump.py --help
```