### PR TITLE
Uses HTTP/1.1 and HOST header for CONNECT method

### DIFF
--- a/websocket/_http.py
+++ b/websocket/_http.py
@@ -273,7 +273,9 @@ def _ssl_socket(sock, user_sslopt, hostname):
 
 def _tunnel(sock, host, port, auth):
     debug("Connecting proxy...")
-    connect_header = "CONNECT %s:%d HTTP/1.0\r\n" % (host, port)
+    connect_header = "CONNECT %s:%d HTTP/1.1\r\n" % (host, port)
+    connect_header += "Host: %s:%d\r\n" % (host, port)
+
     # TODO: support digest auth.
     if auth and auth[0]:
         auth_str = auth[0]


### PR DESCRIPTION
## 1. What is the problem with the current code

I'm behind a proxy and I have a problem that the proxy server blocks websocket-client's connections.
The proxy server reads HOST header in order to filter connections, but I found that websocket-client does not add HOST header to CONNECT method.

cpython's library also has the same problem that websocket-client has. https://github.com/python/cpython/pull/8305 will solve it. 

## 2. How your changes make it better

This adds HOST header to CONNECT method and uses HTTP/1.1.

## 3. Provide some example code that can allow someone else to recreate the problem with the current code and test your solution (if possible to recreate).

https://github.com/websocket-client/websocket-client/blob/master/examples/echo_client.py can be used to recreate.

### Without this PR

```
> python .\examples\echo_client.py
Connecting proxy...
--- request header ---
CONNECT echo.websocket.org:80 HTTP/1.0


-----------------------
--- response header ---
HTTP/1.1 200 OK
Content-Length: 0
Connection: Keep-Alive
-----------------------
--- request header ---
GET / HTTP/1.1
Upgrade: websocket
Host: echo.websocket.org
Origin: http://echo.websocket.org
Sec-WebSocket-Key: PdFFTTmR04GcFC8kbmY3cw==
Sec-WebSocket-Version: 13
Connection: Upgrade


-----------------------
--- response header ---
HTTP/1.1 101 Web Socket Protocol Handshake
Date: Mon, 19 Apr 2021 06:24:51 GMT
Connection: upgrade
Sec-WebSocket-Accept: KA2gx8B0ybeSszDlJMCIy8KnwVs=
Server: Kaazing Gateway
Upgrade: websocket
-----------------------
Sending 'Hello, World'...
send: b'\x81\x8c\xc2v\n6\x8a\x13fZ\xadZ*a\xad\x04fR'
Sent
Receiving...
Received 'Hello, World'
send: b'\x88\x82\xbd\xcd\xfc\xb4\xbe%'
```

### With this PR

```
> python .\examples\echo_client.py
Connecting proxy...
--- request header ---
CONNECT echo.websocket.org:80 HTTP/1.1
Host: echo.websocket.org:80


-----------------------
--- response header ---
HTTP/1.1 200 OK
Content-Length: 0
Connection: Keep-Alive
-----------------------
--- request header ---
GET / HTTP/1.1
Upgrade: websocket
Host: echo.websocket.org
Origin: http://echo.websocket.org
Sec-WebSocket-Key: dSbfvFfqZVo/xBg6eXZEzw==
Sec-WebSocket-Version: 13
Connection: Upgrade


-----------------------
--- response header ---
HTTP/1.1 101 Web Socket Protocol Handshake
Date: Mon, 19 Apr 2021 06:23:39 GMT
Connection: upgrade
Sec-WebSocket-Accept: uQhGtHvbo/ZC9Am8RlfiEMpCjvs=
Server: Kaazing Gateway
Upgrade: websocket
-----------------------
Sending 'Hello, World'...
send: b'\x81\x8c6v\xa9i~\x13\xc5\x05YZ\x89>Y\x04\xc5\r'
Sent
Receiving...
Received 'Hello, World'
send: b'\x88\x82\xb9\x05\x98\xc7\xba\xed'
```