### PR TITLE
Fix: ResourceWarning unclosed socket

### DIFF
--- a/websocket/_http.py
+++ b/websocket/_http.py
@@ -184,6 +184,8 @@ def _open_socket(addrinfo_list, sockopt, timeout):
                     err = error
                     continue
                 else:
+                    if sock:
+                        sock.close()
                     raise error
             else:
                 break


### PR DESCRIPTION
Close socket if error occurs in open_socket. This can happen if websocket is not available. 

**Current Code:**
```
url = 'ws://10.1.1.11:8081/ws'   # any unreachable url is working
ws = websocket.WebSocket()
ws.connect(url=url, timeout=0.1)
```

**Received warning in console:** 
ResourceWarning: unclosed <socket.socket fd=636, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=6, laddr=('0.0.0.0', 56100), raddr=('10.1.1.11', 8081)>