### PR TITLE
Add sslopt parameter 'server_hostname'

### DIFF
--- a/websocket/_http.py
+++ b/websocket/_http.py
@@ -248,6 +248,9 @@ def _ssl_socket(sock, user_sslopt, hostname):
             and user_sslopt.get('ca_cert_path', None) is None:
         sslopt['ca_cert_path'] = certPath
 
+    if sslopt.get('server_hostname', None):
+        hostname = sslopt['server_hostname']
+
     check_hostname = sslopt["cert_reqs"] != ssl.CERT_NONE and sslopt.pop(
         'check_hostname', True)
     sock = _wrap_sni_socket(sock, sslopt, hostname, check_hostname)


### PR DESCRIPTION
At this moment the hostname from connection URL always goes to "server_hostname" of [ssl.SSLContext.wrap_socket](https://docs.python.org/3/library/ssl.html#ssl.SSLContext.wrap_socket). It makes perfect sense for most of use cases, but it's not possible to override it.

However, in some rare cases it might be necessary to pass a custom "server_hostname" parameter for SSL connections. For example, if we want to open an SSL connection to specific IP address, but certificate is valid for hostname only.

```
import websocket

ws = websocket.create_connection(f'wss://xxx.xxx.xxx.xxx:8563', {'sslopt': {'server_hostname': 'my_domain.local'}})
```

Thank you.