### PR TITLE
Updating example for send_frame

### DIFF
--- a/websocket/_core.py
+++ b/websocket/_core.py
@@ -286,7 +286,7 @@ class WebSocket(object):
         Send the data frame.
 
         >>> ws = create_connection("ws://echo.websocket.org/")
-        >>> frame = ABNF.create_frame("Hello", ABNF.OPCODE_TEXT, 0)
+        >>> frame = ABNF.create_frame("Hello. ", ABNF.OPCODE_TEXT, 0)
         >>> ws.send_frame(frame)
         >>> cont_frame = ABNF.create_frame("My name is ", ABNF.OPCODE_CONT, 0)
         >>> ws.send_frame(frame)

--- a/websocket/_core.py
+++ b/websocket/_core.py
@@ -286,7 +286,7 @@ class WebSocket(object):
         Send the data frame.
 
         >>> ws = create_connection("ws://echo.websocket.org/")
-        >>> frame = ABNF.create_frame("Hello", ABNF.OPCODE_TEXT)
+        >>> frame = ABNF.create_frame("Hello", ABNF.OPCODE_TEXT, 0)
         >>> ws.send_frame(frame)
         >>> cont_frame = ABNF.create_frame("My name is ", ABNF.OPCODE_CONT, 0)
         >>> ws.send_frame(frame)


### PR DESCRIPTION
When I tried to run the example for send_frame on a local server (https://github.com/websockets/ws), I got an "op_code invalid" error. I don't think you can start a frame sequence with OPCODE_CONT, and OPCODE_TEXT by default sets the "fin" to true, or 1.

Sending the first message with a fin flag of 0 signals that the message is fragmented, and prevents the server from throwing an error. Not sure if this is unique to the server implementation I used, if it is please let me know! Otherwise I hope this can help someone else.