### PR TITLE
Unquote username and password in proxy from environment

### DIFF
--- a/websocket/_url.py
+++ b/websocket/_url.py
@@ -26,7 +26,7 @@ import os
 import socket
 import struct
 
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 
 
 __all__ = ["parse_url", "get_proxy_info"]
@@ -171,7 +171,7 @@ def get_proxy_info(
         value = os.environ.get(key, os.environ.get(key.upper(), "")).replace(" ", "")
         if value:
             proxy = urlparse(value)
-            auth = (proxy.username, proxy.password) if proxy.username else None
+            auth = (unquote(proxy.username), unquote(proxy.password)) if proxy.username else None
             return proxy.hostname, proxy.port, auth
 
     return None, 0, None

--- a/websocket/tests/test_url.py
+++ b/websocket/tests/test_url.py
@@ -277,6 +277,10 @@ class ProxyInfoTest(unittest.TestCase):
         os.environ["https_proxy"] = "http://a:b@localhost2:3128/"
         self.assertEqual(get_proxy_info("echo.websocket.org", True), ("localhost2", 3128, ("a", "b")))
 
+        os.environ["http_proxy"] = "http://john%40example.com:P%40SSWORD@localhost:3128/"
+        os.environ["https_proxy"] = "http://john%40example.com:P%40SSWORD@localhost2:3128/"
+        self.assertEqual(get_proxy_info("echo.websocket.org", True), ("localhost2", 3128, ("john@example.com", "P@SSWORD")))
+
         os.environ["http_proxy"] = "http://a:b@localhost/"
         os.environ["https_proxy"] = "http://a:b@localhost2/"
         os.environ["no_proxy"] = "example1.com,example2.com"


### PR DESCRIPTION
This fixes e.g. credentials containing a `@` escaped as `%40`.

Closes #722.