### PR TITLE
Fixed on_error not being called

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -408,6 +408,5 @@ class WebSocketApp(object):
 
             except Exception as e:
                 _logging.error("error from callback {}: {}".format(callback, e))
-                if _logging.isEnabledForDebug():
-                    _, _, tb = sys.exc_info()
-                    traceback.print_tb(tb)
+                if self.on_error:
+                    self.on_error(self, e)


### PR DESCRIPTION
The issue: as of current, the on_error callback function defined by the user is not called, unless `_traceEnabled = True`. Which means that in order to get proper exception handling, one also needs to have all the other trace messages that are not necessarily needed and will clutter the console a lot.

By changing the if statement in WebSocketApp._callback, we can ensure that if an error occurs and the on_error function has been specified by the user it WILL get called. Not only does it give the user the choice as to whether or not they want to handle exceptions, it also gives them the option to do so however they please.

The following example illustrates it simply: if one runs this code as is without the changes to the _callback function, the RuntimeError will not appear.
```python
import websocket

def on_open(app: websocket.WebSocketApp):
    app.send('Hello world')
    raise RuntimeError('This is a test error')

def on_message(app: websocket.WebSocketApp, message):
    print(message)

def on_error(app, error: Exception):
    print(error)

app = websocket.WebSocketApp('ws://echo.websocket.org/', on_open=on_open, on_error=on_error, on_message=on_message)

app.run_forever()
```