### PR TITLE
Added documentation for sslopt

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -175,6 +175,21 @@ Please set sslopt to ``{"check_hostname": False}``. (since v0.18.0)
   ws = websocket.WebSocket(sslopt={"check_hostname": False})
   ws.connect("wss://echo.websocket.org")
 
+
+What else can I do with sslopts?
+============================================================================
+
+The ``sslopt`` parameter is a dictionary to which the following keys can be assigned:
+
+* ``certfile``, ``keyfile``, ``password`` (see `SSLContext.load_cert_chain <https://docs.python.org/3/library/ssl.html#ssl.SSLContext.load_cert_chain>`_)
+* ``ecdh_curve`` (see `SSLContext.set_ecdh_curve <https://docs.python.org/3/library/ssl.html#ssl.SSLContext.set_ecdh_curve>`_)
+* ``ciphers`` (see `SSLContext.set_ciphers <https://docs.python.org/3/library/ssl.html#ssl.SSLContext.set_ciphers>`_)
+* ``cert_reqs`` (see `SSLContext.verify_mode <https://docs.python.org/3/library/ssl.html#ssl.SSLContext.verify_mode>`_)
+* ``ssl_version`` (see `SSLContext.protocol <https://docs.python.org/3/library/ssl.html#ssl.SSLContext.protocol>`_)
+* ``ca_certs``, ``ca_cert_path`` (see `SSLContext.load_verify_locations <https://docs.python.org/3/library/ssl.html#ssl.SSLContext.load_verify_locations>`_)
+* ``check_hostname`` (see `SSLContext.check_hostname <https://docs.python.org/3/library/ssl.html#ssl.SSLContext.check_hostname>`_)
+* ``server_hostname``, ``do_handshake_on_connect``, ``suppress_ragged_eofs`` (see `SSLContext.wrap_socket <https://docs.python.org/3/library/ssl.html#ssl.SSLContext.wrap_socket>`_)
+
 How to enable `SNI <http://en.wikipedia.org/wiki/Server_Name_Indication>`_?
 ============================================================================
 

--- a/websocket/_core.py
+++ b/websocket/_core.py
@@ -66,7 +66,7 @@ class WebSocket(object):
         Values for socket.setsockopt.
         sockopt must be tuple and each element is argument of sock.setsockopt.
     sslopt: dict
-        Optional dict object for ssl socket options.
+        Optional dict object for ssl socket options. See FAQ for details.
     fire_cont_frame: bool
         Fire recv event for each cont frame. Default is False.
     enable_multithread: bool
@@ -84,7 +84,7 @@ class WebSocket(object):
         Parameters
         ----------
         sslopt: dict
-            Optional dict object for ssl socket options.
+            Optional dict object for ssl socket options. See FAQ for details.
         """
         self.sock_opt = sock_opt(sockopt, sslopt)
         self.handshake_response = None
@@ -575,7 +575,7 @@ def create_connection(url, timeout=None, class_=WebSocket, **options):
         Values for socket.setsockopt.
         sockopt must be a tuple and each element is an argument of sock.setsockopt.
     sslopt: dict
-        Optional dict object for ssl socket options.
+        Optional dict object for ssl socket options. See FAQ for details.
     subprotocols: list
         List of available subprotocols. Default is None.
     skip_utf8_validation: bool


### PR DESCRIPTION
Multiple functions accept an `sslopt`-dictionary when creating a connection, but so far, there was no documentation on what the dictionary actually does. As different keys of `sslopt` are used on different functions and attributes of the `SSLContext` class, this is not self-explanatory.