### PR TITLE
Update the echo.websocket URL in README and 2 files in examples folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ server is running and responds properly to a specific request.
 ```python
 from websocket import create_connection
 
-ws = create_connection("ws://echo.websocket.org/")
+ws = create_connection("ws://echo.websocket.events/")
+print(ws.recv())
 print("Sending 'Hello, World'...")
 ws.send("Hello, World")
 print("Sent")

--- a/examples/echo_client.py
+++ b/examples/echo_client.py
@@ -2,7 +2,8 @@ import websocket
 
 if __name__ == "__main__":
     websocket.enableTrace(True)
-    ws = websocket.create_connection("ws://echo.websocket.org/")
+    ws = websocket.create_connection("ws://echo.websocket.events/")
+    ws.recv()
     print("Sending 'Hello, World'...")
     ws.send("Hello, World")
     print("Sent")

--- a/examples/echoapp_client.py
+++ b/examples/echoapp_client.py
@@ -35,7 +35,7 @@ def on_open(ws):
 if __name__ == "__main__":
     websocket.enableTrace(True)
     if len(sys.argv) < 2:
-        host = "ws://echo.websocket.org/"
+        host = "ws://echo.websocket.events/"
     else:
         host = sys.argv[1]
     ws = websocket.WebSocketApp(host,


### PR DESCRIPTION
echo.websocket.org is no longer available, so replacing with an alternate server that will echo back whatever you send via websockets.

I explored the use of echo.websocket.org in examples.rst and they go beyond a basic echo demonstrate proxying, custom headers, and other advanced use cases.

Since, echo.websocket.events is currently just a basic echo-server it doesn't seem appropriate for those use cases.  For this reason, I didn't modify any of the examples in the docs folder.

Hopefully the community finds this change useful 

Reference issue #779 