### PR TITLE
fix!: `WebSocketApp.run_forever()` returning `None` after `close()` is called

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -258,7 +258,8 @@ class WebSocketApp:
         Returns
         -------
         teardown: bool
-            False if caught KeyboardInterrupt, True if other exception was raised during a loop
+            False if the `WebSocketApp` is closed or caught KeyboardInterrupt,
+            True if any other exception was raised during a loop.
         """
 
         if ping_timeout is not None and ping_timeout <= 0:
@@ -367,6 +368,7 @@ class WebSocketApp:
                 return True
 
             dispatcher.read(self.sock.sock, read, check)
+            return False
         except (Exception, KeyboardInterrupt, SystemExit) as e:
             self._callback(self.on_error, e)
             if isinstance(e, SystemExit):

--- a/websocket/tests/test_app.py
+++ b/websocket/tests/test_app.py
@@ -128,7 +128,6 @@ class WebSocketAppTest(unittest.TestCase):
         self.assertEqual(teardown, True)
         self.assertTrue(len(WebSocketAppTest.on_error_data) > 0)
 
-
     @unittest.skipUnless(TEST_WITH_INTERNET, "Internet-requiring tests are disabled")
     def testSockMaskKey(self):
         """ A WebSocketApp should forward the received mask_key function down

--- a/websocket/tests/test_app.py
+++ b/websocket/tests/test_app.py
@@ -21,6 +21,7 @@ limitations under the License.
 
 import os
 import os.path
+import threading
 import websocket as ws
 import ssl
 import unittest
@@ -45,11 +46,13 @@ class WebSocketAppTest(unittest.TestCase):
         WebSocketAppTest.keep_running_open = WebSocketAppTest.NotSetYet()
         WebSocketAppTest.keep_running_close = WebSocketAppTest.NotSetYet()
         WebSocketAppTest.get_mask_key_id = WebSocketAppTest.NotSetYet()
+        WebSocketAppTest.on_error_data = WebSocketAppTest.NotSetYet()
 
     def tearDown(self):
         WebSocketAppTest.keep_running_open = WebSocketAppTest.NotSetYet()
         WebSocketAppTest.keep_running_close = WebSocketAppTest.NotSetYet()
         WebSocketAppTest.get_mask_key_id = WebSocketAppTest.NotSetYet()
+        WebSocketAppTest.on_error_data = WebSocketAppTest.NotSetYet()
 
     @unittest.skipUnless(TEST_WITH_LOCAL_SERVER, "Tests using local websocket server are disabled")
     def testKeepRunning(self):
@@ -96,6 +99,35 @@ class WebSocketAppTest(unittest.TestCase):
 
         app = ws.WebSocketApp('ws://127.0.0.1:' + LOCAL_WS_SERVER_PORT, on_open=on_open, on_message=on_message)
         app.run_forever(dispatcher="Dispatcher")
+
+    @unittest.skipUnless(TEST_WITH_LOCAL_SERVER, "Tests using local websocket server are disabled")
+    def testRunForeverTeardownCleanExit(self):
+        """ The WebSocketApp.run_forever() method should return `False` when the application ends gracefully.
+        """
+        app = ws.WebSocketApp('ws://127.0.0.1:' + LOCAL_WS_SERVER_PORT)
+        threading.Timer(interval=0.2, function=app.close).start()
+        teardown = app.run_forever()
+        self.assertEqual(teardown, False)
+
+    @unittest.skipUnless(TEST_WITH_LOCAL_SERVER, "Tests using local websocket server are disabled")
+    def testRunForeverTeardownExceptionalExit(self):
+        """ The WebSocketApp.run_forever() method should return `True` when the application ends with an exception.
+        It should also invoke the `on_error` callback before exiting.
+        """
+
+        def break_it():
+            # Deliberately break the WebSocketApp by closing the inner socket.
+            app.sock.close()
+
+        def on_error(_, err):
+            WebSocketAppTest.on_error_data = str(err)
+
+        app = ws.WebSocketApp('ws://127.0.0.1:' + LOCAL_WS_SERVER_PORT, on_error=on_error)
+        threading.Timer(interval=0.2, function=break_it).start()
+        teardown = app.run_forever(ping_timeout=0.1)
+        self.assertEqual(teardown, True)
+        self.assertTrue(len(WebSocketAppTest.on_error_data) > 0)
+
 
     @unittest.skipUnless(TEST_WITH_INTERNET, "Internet-requiring tests are disabled")
     def testSockMaskKey(self):

--- a/websocket/tests/test_app.py
+++ b/websocket/tests/test_app.py
@@ -106,7 +106,7 @@ class WebSocketAppTest(unittest.TestCase):
         def my_mask_key_func():
             return "\x00\x00\x00\x00"
 
-        app = ws.WebSocketApp('wss://stream.meetup.com/2/rsvps', get_mask_key=my_mask_key_func)
+        app = ws.WebSocketApp('wss://api-pub.bitfinex.com/ws/1', get_mask_key=my_mask_key_func)
 
         # if numpy is installed, this assertion fail
         # Note: We can't use 'is' for comparing the functions directly, need to use 'id'.

--- a/websocket/tests/test_websocket.py
+++ b/websocket/tests/test_websocket.py
@@ -201,14 +201,16 @@ class WebSocketTest(unittest.TestCase):
     @unittest.skipUnless(TEST_WITH_INTERNET, "Internet-requiring tests are disabled")
     def testIter(self):
         count = 2
-        for _ in ws.create_connection('wss://stream.meetup.com/2/rsvps'):
+        s = ws.create_connection('wss://api.bitfinex.com/ws/2')
+        s.send('{"event": "subscribe", "channel": "ticker"}')
+        for _ in s:
             count -= 1
             if count == 0:
                 break
 
     @unittest.skipUnless(TEST_WITH_INTERNET, "Internet-requiring tests are disabled")
     def testNext(self):
-        sock = ws.create_connection('wss://stream.meetup.com/2/rsvps')
+        sock = ws.create_connection('wss://api.bitfinex.com/ws/2')
         self.assertEqual(str, type(next(sock)))
 
     def testInternalRecvStrict(self):


### PR DESCRIPTION
Closes #785 

BREAKING CHANGE: the return value of `WebSocketApp.run_forever()` will no longer return the (undocumented) `None` value.