### PR TITLE
Allow passing `http_proxy_timeout` to `run_forever`.

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -228,6 +228,7 @@ class WebSocketApp:
                     ping_payload="",
                     http_proxy_host=None, http_proxy_port=None,
                     http_no_proxy=None, http_proxy_auth=None,
+                    http_proxy_timeout=None,
                     skip_utf8_validation=False,
                     host=None, origin=None, dispatcher=None,
                     suppress_origin=False, proxy_type=None):
@@ -256,6 +257,10 @@ class WebSocketApp:
             HTTP proxy host name.
         http_proxy_port: int or str
             HTTP proxy port. If not set, set to 80.
+        http_proxy_timeout: int or float
+            HTTP proxy timeout, defaults to 60 sec.
+        http_proxy_auth: tuple
+            HTTP proxy auth information. tuple of username and password. Default is None.
         http_no_proxy: list
             Whitelisted host names that don't use the proxy.
         skip_utf8_validation: bool
@@ -328,7 +333,8 @@ class WebSocketApp:
                 self.url, header=self.header, cookie=self.cookie,
                 http_proxy_host=http_proxy_host,
                 http_proxy_port=http_proxy_port, http_no_proxy=http_no_proxy,
-                http_proxy_auth=http_proxy_auth, subprotocols=self.subprotocols,
+                http_proxy_auth=http_proxy_auth, http_proxy_timeout=http_proxy_timeout,
+                subprotocols=self.subprotocols,
                 host=host, origin=origin, suppress_origin=suppress_origin,
                 proxy_type=proxy_type, socket=self.prepared_socket)
             dispatcher = self.create_dispatcher(ping_timeout, dispatcher)

--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -258,7 +258,7 @@ class WebSocketApp:
         http_proxy_port: int or str
             HTTP proxy port. If not set, set to 80.
         http_proxy_timeout: int or float
-            HTTP proxy timeout, defaults to 60 sec.
+            HTTP proxy timeout, default is 60 sec as per python-socks.
         http_proxy_auth: tuple
             HTTP proxy auth information. tuple of username and password. Default is None.
         http_no_proxy: list

--- a/websocket/_core.py
+++ b/websocket/_core.py
@@ -575,7 +575,7 @@ def create_connection(url, timeout=None, class_=WebSocket, **options):
     http_proxy_auth: tuple
         HTTP proxy auth information. tuple of username and password. Default is None.
     http_proxy_timeout: int or float
-        HTTP proxy timeout, defaults to 60 sec.
+        HTTP proxy timeout, default is 60 sec as per python-socks.
     enable_multithread: bool
         Enable lock for multithread.
     redirect_limit: int

--- a/websocket/_core.py
+++ b/websocket/_core.py
@@ -233,6 +233,8 @@ class WebSocket:
             Whitelisted host names that don't use the proxy.
         http_proxy_auth: tuple
             HTTP proxy auth information. Tuple of username and password. Default is None.
+        http_proxy_timeout: int or float
+            HTTP proxy timeout, default is 60 sec as per python-socks.
         redirect_limit: int
             Number of redirects to follow.
         subprotocols: list
@@ -572,6 +574,8 @@ def create_connection(url, timeout=None, class_=WebSocket, **options):
         Whitelisted host names that don't use the proxy.
     http_proxy_auth: tuple
         HTTP proxy auth information. tuple of username and password. Default is None.
+    http_proxy_timeout: int or float
+        HTTP proxy timeout, defaults to 60 sec.
     enable_multithread: bool
         Enable lock for multithread.
     redirect_limit: int

--- a/websocket/_http.py
+++ b/websocket/_http.py
@@ -23,7 +23,7 @@ import sys
 
 from ._exceptions import *
 from ._logging import *
-from ._socket import*
+from ._socket import *
 from ._ssl_compat import *
 from ._url import *
 

--- a/websocket/_http.py
+++ b/websocket/_http.py
@@ -59,7 +59,7 @@ class proxy_info:
             self.no_proxy = options.get("http_no_proxy", None)
             self.proxy_protocol = options.get("proxy_type", "http")
             # Note: If timeout not specified, default python-socks timeout is 60 seconds
-            self.proxy_timeout = options.get("timeout", None)
+            self.proxy_timeout = options.get("http_proxy_timeout", None)
             if self.proxy_protocol not in ['http', 'socks4', 'socks4a', 'socks5', 'socks5h']:
                 raise ProxyError("Only http, socks4, socks5 proxy protocols are supported")
         else:

--- a/websocket/tests/test_http.py
+++ b/websocket/tests/test_http.py
@@ -105,15 +105,15 @@ class HttpTest(unittest.TestCase):
         if ws._http.HAVE_PYTHON_SOCKS:
             # Need this check, otherwise case where python_socks is not installed triggers
             # websocket._exceptions.WebSocketException: Python Socks is needed for SOCKS proxying but is not available
-            self.assertRaises((ProxyTimeoutError, OSError), _start_proxied_socket, "wss://example.com", OptsList(), proxy_info(http_proxy_host="example.com", http_proxy_port="8080", proxy_type="socks4", timeout=1))
-            self.assertRaises((ProxyTimeoutError, OSError), _start_proxied_socket, "wss://example.com", OptsList(), proxy_info(http_proxy_host="example.com", http_proxy_port="8080", proxy_type="socks4a", timeout=1))
-            self.assertRaises((ProxyTimeoutError, OSError), _start_proxied_socket, "wss://example.com", OptsList(), proxy_info(http_proxy_host="example.com", http_proxy_port="8080", proxy_type="socks5", timeout=1))
-            self.assertRaises((ProxyTimeoutError, OSError), _start_proxied_socket, "wss://example.com", OptsList(), proxy_info(http_proxy_host="example.com", http_proxy_port="8080", proxy_type="socks5h", timeout=1))
-            self.assertRaises(ProxyConnectionError, connect, "wss://example.com", OptsList(), proxy_info(http_proxy_host="127.0.0.1", http_proxy_port=9999, proxy_type="socks4", timeout=1), None)
+            self.assertRaises((ProxyTimeoutError, OSError), _start_proxied_socket, "wss://example.com", OptsList(), proxy_info(http_proxy_host="example.com", http_proxy_port="8080", proxy_type="socks4", http_proxy_timeout=1))
+            self.assertRaises((ProxyTimeoutError, OSError), _start_proxied_socket, "wss://example.com", OptsList(), proxy_info(http_proxy_host="example.com", http_proxy_port="8080", proxy_type="socks4a", http_proxy_timeout=1))
+            self.assertRaises((ProxyTimeoutError, OSError), _start_proxied_socket, "wss://example.com", OptsList(), proxy_info(http_proxy_host="example.com", http_proxy_port="8080", proxy_type="socks5", http_proxy_timeout=1))
+            self.assertRaises((ProxyTimeoutError, OSError), _start_proxied_socket, "wss://example.com", OptsList(), proxy_info(http_proxy_host="example.com", http_proxy_port="8080", proxy_type="socks5h", http_proxy_timeout=1))
+            self.assertRaises(ProxyConnectionError, connect, "wss://example.com", OptsList(), proxy_info(http_proxy_host="127.0.0.1", http_proxy_port=9999, proxy_type="socks4", http_proxy_timeout=1), None)
 
         self.assertRaises(TypeError, _get_addrinfo_list, None, 80, True, proxy_info(http_proxy_host="127.0.0.1", http_proxy_port="9999", proxy_type="http"))
         self.assertRaises(TypeError, _get_addrinfo_list, None, 80, True, proxy_info(http_proxy_host="127.0.0.1", http_proxy_port="9999", proxy_type="http"))
-        self.assertRaises(socket.timeout, connect, "wss://google.com", OptsList(), proxy_info(http_proxy_host="8.8.8.8", http_proxy_port=9999, proxy_type="http", timeout=1), None)
+        self.assertRaises(socket.timeout, connect, "wss://google.com", OptsList(), proxy_info(http_proxy_host="8.8.8.8", http_proxy_port=9999, proxy_type="http", http_proxy_timeout=1), None)
         self.assertEqual(
             connect("wss://google.com", OptsList(), proxy_info(http_proxy_host="8.8.8.8", http_proxy_port=8080, proxy_type="http"), True),
             (True, ("google.com", 443, "/")))


### PR DESCRIPTION
See https://github.com/websocket-client/websocket-client/issues/841

This PR allows to pass timeout for proxy in `run_forever`. Default timeout is quite long (60 sec) so this way user can set it's own.