### PR TITLE
Fix reconnect with SSLDispatcher

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -39,6 +39,10 @@ class DispatcherBase:
         self.app = app
         self.ping_timeout = ping_timeout
 
+    def timeout(self, seconds, callback):
+        time.sleep(seconds)
+        callback()
+
 
 class Dispatcher(DispatcherBase):
     """
@@ -55,10 +59,6 @@ class Dispatcher(DispatcherBase):
                     break
             check_callback()
             sel.close()
-
-    def timeout(self, seconds, callback):
-        time.sleep(seconds)
-        callback()
 
 
 class SSLDispatcher(DispatcherBase):


### PR DESCRIPTION
The default SSLDispatcher lacks a "timeout" method, which leads to the following when reconnecting:
```
Traceback (most recent call last):
  File "/workspace/.venv/lib/python3.10/site-packages/websocket/_app.py", line 363, in read
    op_code, frame = self.sock.recv_data_frame(True)
  File "/workspace/.venv/lib/python3.10/site-packages/websocket/_core.py", line 403, in recv_data_frame
    frame = self.recv_frame()
  File "/workspace/.venv/lib/python3.10/site-packages/websocket/_core.py", line 442, in recv_frame
    return self.frame_buffer.recv_frame()
  File "/workspace/.venv/lib/python3.10/site-packages/websocket/_abnf.py", line 338, in recv_frame
    self.recv_header()
  File "/workspace/.venv/lib/python3.10/site-packages/websocket/_abnf.py", line 294, in recv_header
    header = self.recv_strict(2)
  File "/workspace/.venv/lib/python3.10/site-packages/websocket/_abnf.py", line 373, in recv_strict
    bytes_ = self.recv(min(16384, shortage))
  File "/workspace/.venv/lib/python3.10/site-packages/websocket/_core.py", line 526, in _recv
    return recv(self.sock, bufsize)
  File "/workspace/.venv/lib/python3.10/site-packages/websocket/_socket.py", line 122, in recv
    raise WebSocketConnectionClosedException(
websocket._exceptions.WebSocketConnectionClosedException: Connection to remote host was lost.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/workspace/.venv/lib/python3.10/site-packages/websocket/_app.py", line 354, in setSock
    dispatcher.read(self.sock.sock, read, check)
  File "/workspace/.venv/lib/python3.10/site-packages/websocket/_app.py", line 72, in read
    if not read_callback():
  File "/workspace/.venv/lib/python3.10/site-packages/websocket/_app.py", line 366, in read
    return handleDisconnect(e)
  File "/workspace/.venv/lib/python3.10/site-packages/websocket/_app.py", line 407, in handleDisconnect
    dispatcher.timeout(reconnect, setSock)
AttributeError: 'SSLDispatcher' object has no attribute 'timeout'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/workspace/opsicommon/client/opsiservice.py", line 630, in run
    self._connect()
  File "/workspace/opsicommon/client/opsiservice.py", line 605, in _connect
    self._app.run_forever(  # type: ignore[attr-defined]
  File "/workspace/.venv/lib/python3.10/site-packages/websocket/_app.py", line 420, in run_forever
    setSock()
  File "/workspace/.venv/lib/python3.10/site-packages/websocket/_app.py", line 356, in setSock
    handleDisconnect(e)
  File "/workspace/.venv/lib/python3.10/site-packages/websocket/_app.py", line 407, in handleDisconnect
    dispatcher.timeout(reconnect, setSock)
AttributeError: 'SSLDispatcher' object has no attribute 'timeout'
```