### PR TITLE
WebSocketApp._send_ping(): omit break on ping failure

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -251,7 +251,7 @@ class WebSocketApp:
                     self.sock.ping(payload)
                 except Exception as ex:
                     _logging.warning("send_ping routine terminated: {}".format(ex))
-                    break
+#                    break # do we need this break for something?
 
     def run_forever(self, sockopt=None, sslopt=None,
                     ping_interval=0, ping_timeout=None,


### PR DESCRIPTION
omit break that causes pings to halt after failure (even post-reconnect).

may fix:

https://github.com/websocket-client/websocket-client/issues/858