### PR TITLE
Possible* Redundancy In Key Generation

### DIFF
--- a/websocket/_handshake.py
+++ b/websocket/_handshake.py
@@ -101,7 +101,6 @@ def _get_handshake_headers(resource, url, host, port, options):
 
     # Append Sec-WebSocket-Key & Sec-WebSocket-Version if not manually specified
     if not options.get('header') or 'Sec-WebSocket-Key' not in options['header']:
-        key = _create_sec_websocket_key()
         headers.append("Sec-WebSocket-Key: %s" % key)
     else:
         key = options['header']['Sec-WebSocket-Key']


### PR DESCRIPTION
Was digging through the code base the past few days as it's been an excellent aid in learning about Websockets and TCP. Noticed _create_sec_websocket_key was getting called twice per ws.connect method. I may be missing something, but thought I would bring it to your attention in case it's an artifact or something. Best Regards!