### PR TITLE
Update docs to fix #863

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,17 @@ Many more examples are found in the
 Most real-world WebSockets situations involve longer-lived connections.
 The WebSocketApp `run_forever` loop will automatically try to reconnect
 to an open WebSocket connection when a network
-connection is lost if it is provided with a dispatcher parameter,
-and provides a variety of event-based connection controls.
+connection is lost if it is provided with:
+
+- a `dispatcher` argument (async dispatcher like rel or pyevent)
+- a non-zero `reconnect` argument (delay between disconnection and attempted reconnection)
+
+`run_forever` provides a variety of event-based connection controls
+using callbacks like `on_message` and `on_error`.
 `run_forever` does not automatically reconnect if the server
-closes the WebSocket. Customizing behavior when the server closes
+closes the WebSocket gracefully (returning
+[a standard websocket close code](https://www.rfc-editor.org/rfc/rfc6455.html#section-7.4.1)).
+Customizing behavior when the server closes
 the WebSocket should be handled in the `on_close` callback.
 This example uses [rel](https://github.com/bubbleboy14/registeredeventlistener)
 for the dispatcher to provide automatic reconnection.
@@ -107,7 +114,7 @@ if __name__ == "__main__":
                               on_error=on_error,
                               on_close=on_close)
 
-    ws.run_forever(dispatcher=rel)  # Set dispatcher to automatic reconnection
+    ws.run_forever(dispatcher=rel, reconnect=5)  # Set dispatcher to automatic reconnection, 5 second reconnect delay if connection closed unexpectedly
     rel.signal(2, rel.abort)  # Keyboard Interrupt
     rel.dispatch()
 ```

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -700,7 +700,7 @@ You can use an asynchronous dispatcher such as `rel <https://pypi.org/project/re
   >>> addr = "wss://api.gemini.com/v1/marketdata/%s"
   >>> for symbol in ["BTCUSD", "ETHUSD", "ETHBTC"]:
   ...     ws = websocket.WebSocketApp(addr % (symbol,), on_message=lambda w, m : print(m))
-  ...     ws.run_forever(dispatcher=rel)  # doctest: +SKIP
+  ...     ws.run_forever(dispatcher=rel, reconnect=3)  # doctest: +SKIP
   >>> rel.signal(2, rel.abort)  # Keyboard Interrupt  # doctest: +SKIP
   >>> rel.dispatch()  # doctest: +SKIP
 
@@ -739,7 +739,7 @@ The examples are found in the README and are copied here for sphinx doctests to 
   ...                               on_error=on_error,
   ...                               on_close=on_close)
 
-  >>> ws.run_forever(dispatcher=rel)  # Set dispatcher to automatic reconnection  # doctest: +SKIP
+  >>> ws.run_forever(dispatcher=rel, reconnect=5)  # Set dispatcher to automatic reconnection, 5 second reconnect delay if connection closed unexpectedly  # doctest: +SKIP
   >>> rel.signal(2, rel.abort)  # Keyboard Interrupt
   <Signal Object | Callback:"abort">
   >>> rel.dispatch()  # doctest: +SKIP

--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -287,12 +287,12 @@ class WebSocketApp:
             HTTP proxy host name.
         http_proxy_port: int or str
             HTTP proxy port. If not set, set to 80.
+        http_no_proxy: list
+            Whitelisted host names that don't use the proxy.
         http_proxy_timeout: int or float
             HTTP proxy timeout, default is 60 sec as per python-socks.
         http_proxy_auth: tuple
             HTTP proxy auth information. tuple of username and password. Default is None.
-        http_no_proxy: list
-            Whitelisted host names that don't use the proxy.
         skip_utf8_validation: bool
             skip utf8 validation.
         host: str
@@ -303,6 +303,10 @@ class WebSocketApp:
             customize reading data from socket.
         suppress_origin: bool
             suppress outputting origin header.
+        proxy_type: str
+            type of proxy from: http, socks4, socks4a, socks5, socks5h
+        reconnect: int
+            delay interval when reconnecting
 
         Returns
         -------


### PR DESCRIPTION
1. Fix `run_forever` docstrings to include proxy_type, reconnect kwargs
2. Edit README to clarify the need for a `reconnect` value and include this value in the long-lived connection example. Further clarify lack of automatic reconnect when the server returns a standard close code to close the connection gracefully.
3. Add `reconnect` kwarg to some Examples documentation code

Items that still need consideration for `run_forever` reconnection:
1. Must `reconnect` be a non-zero value? Should we permit the client to immediately reconnect without delay?
2. `run_forever` does not automatically reconnect if the server closes the WebSocket gracefully, but would it make sense to add a flag to force reconnecting even if the server had a reason to disconnect gracefully?

