### PR TITLE
create_dispatcher() w/ is_ssl determined by url instead of sslopt

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -441,7 +441,7 @@ class WebSocketApp:
                 teardown()
 
         custom_dispatcher = bool(dispatcher)
-        dispatcher = self.create_dispatcher(ping_timeout, dispatcher, self.url.startswith("wss://"))
+        dispatcher = self.create_dispatcher(ping_timeout, dispatcher, self.url.lower().startswith("wss://"))
 
         if ping_interval:
             event = threading.Event()

--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -5,6 +5,7 @@ import threading
 import time
 import traceback
 from ._abnf import ABNF
+from ._url import parse_url
 from ._core import WebSocket, getdefaulttimeout
 from ._exceptions import *
 from . import _logging
@@ -441,7 +442,7 @@ class WebSocketApp:
                 teardown()
 
         custom_dispatcher = bool(dispatcher)
-        dispatcher = self.create_dispatcher(ping_timeout, dispatcher, self.url.lower().startswith("wss://"))
+        dispatcher = self.create_dispatcher(ping_timeout, dispatcher, parse_url(self.url)[3])
 
         if ping_interval:
             event = threading.Event()

--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -441,7 +441,7 @@ class WebSocketApp:
                 teardown()
 
         custom_dispatcher = bool(dispatcher)
-        dispatcher = self.create_dispatcher(ping_timeout, dispatcher, not not sslopt)
+        dispatcher = self.create_dispatcher(ping_timeout, dispatcher, self.url.startswith("wss://"))
 
         if ping_interval:
             event = threading.Event()

--- a/websocket/tests/test_app.py
+++ b/websocket/tests/test_app.py
@@ -191,7 +191,7 @@ class WebSocketAppTest(unittest.TestCase):
         """ Test WebSocketApp binary opcode
         """
         # The lack of wss:// in the URL below is on purpose
-        app = ws.WebSocketApp('streaming.vn.teslamotors.com/streaming/')
+        app = ws.WebSocketApp('wss://streaming.vn.teslamotors.com/streaming/')
         app.run_forever(ping_interval=2, ping_timeout=1, ping_payload="Ping payload")
 
     @unittest.skipUnless(TEST_WITH_INTERNET, "Internet-requiring tests are disabled")


### PR DESCRIPTION
see: https://github.com/websocket-client/websocket-client/issues/857