### PR TITLE
Reduce "websocket connected" log to INFO level

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -379,7 +379,7 @@ class WebSocketApp:
 
                 self._callback(self.on_open)
 
-                _logging.warning("websocket connected")
+                _logging.info("websocket connected")
                 dispatcher.read(self.sock.sock, read, check)
             except (WebSocketConnectionClosedException, ConnectionRefusedError, KeyboardInterrupt, SystemExit, Exception) as e:
                 _logging.error("%s - %s" % (e, reconnect and "reconnecting" or "goodbye"))


### PR DESCRIPTION
This doesn't seem like it should be a warning. A connection was requested and a connection was made so INFO seems like a more appropriate level for this message.

I believe this is the warning #865 was referring to.