### PR TITLE
Relying on a header that might not be present, so added a header check

### DIFF
--- a/websocket/_handshake.py
+++ b/websocket/_handshake.py
@@ -131,7 +131,7 @@ def _get_handshake_headers(resource, url, host, port, options):
     client_cookie = options.get("cookie", None)
 
     cookie = "; ".join(filter(None, [server_cookie, client_cookie]))
-    
+
     if cookie:
         headers.append("Cookie: {cookie}".format(cookie=cookie))
 

--- a/websocket/_handshake.py
+++ b/websocket/_handshake.py
@@ -144,7 +144,10 @@ def _get_handshake_headers(resource, url, host, port, options):
 def _get_resp_headers(sock, success_statuses=SUCCESS_STATUSES):
     status, resp_headers, status_message = read_headers(sock)
     if status not in success_statuses:
-        response_body = sock.recv(int(resp_headers['content-length']))  # read the body of the HTTP error message response and include it in the exception
+        if content_len := resp_headers.get('content-length'):
+            response_body = sock.recv(int(content_len))  # read the body of the HTTP error message response and include it in the exception
+        else:
+            response_body = None
         raise WebSocketBadStatusException("Handshake status {status} {message} -+-+- {headers} -+-+- {body}".format(status=status, message=status_message, headers=resp_headers, body=response_body), status, status_message, resp_headers, response_body)
     return status, resp_headers
 

--- a/websocket/_handshake.py
+++ b/websocket/_handshake.py
@@ -130,14 +130,10 @@ def _get_handshake_headers(resource, url, host, port, options):
     server_cookie = CookieJar.get(host)
     client_cookie = options.get("cookie", None)
 
-    cookie = "; ".join(filter(None, [server_cookie, client_cookie]))
-
-    if cookie:
+    if cookie := "; ".join(filter(None, [server_cookie, client_cookie])):
         headers.append("Cookie: {cookie}".format(cookie=cookie))
 
-    headers.append("")
-    headers.append("")
-
+    headers.extend(("", ""))
     return headers, key
 
 

--- a/websocket/_handshake.py
+++ b/websocket/_handshake.py
@@ -130,7 +130,9 @@ def _get_handshake_headers(resource, url, host, port, options):
     server_cookie = CookieJar.get(host)
     client_cookie = options.get("cookie", None)
 
-    if cookie := "; ".join(filter(None, [server_cookie, client_cookie])):
+    cookie = "; ".join(filter(None, [server_cookie, client_cookie]))
+    
+    if cookie:
         headers.append("Cookie: {cookie}".format(cookie=cookie))
 
     headers.extend(("", ""))
@@ -140,7 +142,8 @@ def _get_handshake_headers(resource, url, host, port, options):
 def _get_resp_headers(sock, success_statuses=SUCCESS_STATUSES):
     status, resp_headers, status_message = read_headers(sock)
     if status not in success_statuses:
-        if content_len := resp_headers.get('content-length'):
+        content_len = resp_headers.get('content-length')
+        if content_len:
             response_body = sock.recv(int(content_len))  # read the body of the HTTP error message response and include it in the exception
         else:
             response_body = None


### PR DESCRIPTION
I found a case where `_get_resp_headers` gets a `KeyError`.

Here are the `status`, `resp_headers`, and `status_message` that were obtained by `read_headers`:

```text
status = 404
resp_headers = {'date': 'Fri, 26 May 2023 22:34:07 GMT', 'server': 'WSGIServer/0.2 CPython/3.11.3', 'content-type': 'text/html', 'vary': 'Origin, Cookie', 'access-control-allow-origin': '*', 'connection': 'close'}
status_message = 'Not Found'
```

I looked at the HTTP spec:
> For response messages, whether or not an entity body is included with a message is dependent on both the request method and the response code. All responses to the HEAD request method must not include a body, even though the presence of entity header fields may lead one to believe they do. All 1xx (informational), 204 (no content), and 304 (not modified) responses must not include a body. All other responses must include an entity body or a Content-Length header field defined with a value of zero (0).

-- [spec](https://www.w3.org/Protocols/HTTP/1.0/draft-ietf-http-spec.html#Entity-Body)

I think that says that the server should have sent a Content-Length header, but maybe the code shouldn't crash?

After my change, I get this:
> websocket._exceptions.WebSocketBadStatusException: Handshake status 404 Not Found -+-+- {'date': 'Fri, 26 May 2023 22:53:52 GMT', 'server': 'WSGIServer/0.2 CPython/3.11.3', 'content-type': 'text/html', 'vary': 'Origin, Cookie', 'access-control-allow-origin': '*', 'connection': 'close'} -+-+- None

Maybe `response_body = ''` would be better, but here is something to start with.