### PR TITLE
Fix first round ping waiting 2 x interval.

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -270,7 +270,9 @@ class WebSocketApp:
     def _send_ping(self) -> None:
         if self.stop_ping.wait(self.ping_interval):
             return
-        while not self.stop_ping.wait(self.ping_interval):
+        first_round = True
+        while first_round or not self.stop_ping.wait(self.ping_interval):
+            first_round = False
             if self.sock:
                 self.last_ping_tm = time.time()
                 try:


### PR DESCRIPTION
https://github.com/websocket-client/websocket-client/blob/7c39ddb91d6ed07974f3435d96e0d57a40435e54/websocket/_app.py#L270-L274

The first round of ping out will wait 2 times the interval, because there are 2 waits blocked, so, I added a variable to identify whether it is the first round.