### PR TITLE
Change tuple typing for recv

### DIFF
--- a/websocket/_wsdump.py
+++ b/websocket/_wsdump.py
@@ -154,18 +154,18 @@ def main() -> None:
         console = InteractiveConsole()
         print("Press Ctrl+C to quit")
 
-    def recv() -> tuple(int, str):
+    def recv() -> tuple[int, str]:
         try:
             frame = ws.recv_frame()
         except websocket.WebSocketException:
-            return websocket.ABNF.OPCODE_CLOSE, None
+            return websocket.ABNF.OPCODE_CLOSE, ""
         if not frame:
             raise websocket.WebSocketException("Not a valid frame {frame}".format(frame=frame))
         elif frame.opcode in OPCODE_DATA:
             return frame.opcode, frame.data
         elif frame.opcode == websocket.ABNF.OPCODE_CLOSE:
             ws.send_close()
-            return frame.opcode, None
+            return frame.opcode, ""
         elif frame.opcode == websocket.ABNF.OPCODE_PING:
             ws.pong(frame.data)
             return frame.opcode, frame.data


### PR DESCRIPTION
Currently by executing simple command:

    wsdump --nocert -r -t '{"logfile":"console.log"}' wss://localhost/api/tenant/internal/console-stream

It raises an error:

    Traceback (most recent call last):
      File "/home/centos/.local/bin/wsdump", line 9, in <module>
        sys.exit(main())
      File "/home/centos/.local/lib/python3.9/site-packages/websocket/_wsdump.py", line 158, in main
        def recv() -> tuple(int, str):
    TypeError: tuple expected at most 1 argument, got 2

According to the python doc [1], tuple should be in square brackets.

[1] https://docs.python.org/3/library/typing.html