### PR TITLE
DispatcherBase.reconnect(): raise KeyboardInterrupt to prevent gettin…

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -503,8 +503,8 @@ class WebSocketApp:
                 while self.keep_running:
                     _logging.debug("Calling dispatcher reconnect [{frame_count} frames in stack]".format(frame_count=len(inspect.stack())))
                     dispatcher.reconnect(reconnect, setSock)
-        except:
-            _logging.info("tearing down on exception")
+        except (KeyboardInterrupt, Exception) as e:
+            _logging.info("tearing down on exception {err}".format(err=e))
             teardown()
         finally:
             if not custom_dispatcher:

--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -63,6 +63,7 @@ class DispatcherBase:
             reconnector(reconnecting=True)
         except KeyboardInterrupt as e:
             _logging.info("User exited {err}".format(err=e))
+            raise e
 
 
 class Dispatcher(DispatcherBase):
@@ -502,9 +503,13 @@ class WebSocketApp:
                 while self.keep_running:
                     _logging.debug("Calling dispatcher reconnect [{frame_count} frames in stack]".format(frame_count=len(inspect.stack())))
                     dispatcher.reconnect(reconnect, setSock)
-        finally:
-            # Ensure teardown was called before returning from run_forever
+        except:
+            _logging.info("tearing down on exception")
             teardown()
+        finally:
+            if not custom_dispatcher:
+                # Ensure teardown was called before returning from run_forever
+                teardown()
 
         return self.has_errored
 


### PR DESCRIPTION
…g stuck in reconnect loop. WebSocketApp.run_forever(): only teardown() in finally if not custom_dispatcher (avoids immediately closing connection); added except case that logs and calls teardown(), catching things like KeyboardInterrupt.

may fix: https://github.com/websocket-client/websocket-client/issues/923