### PR TITLE
Add support for SSLKEYLOGFILE

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,9 @@
 ChangeLog
 ============
 
+- Unreleased
+  - Add support for SSLKEYLOGFILE
+
 - 1.6.1
   - Fix Dispatcher keyboard interrupt. Should solve reconnect loop with rel (#924)
 

--- a/websocket/_http.py
+++ b/websocket/_http.py
@@ -211,6 +211,11 @@ def _wrap_sni_socket(sock, sslopt, hostname, check_hostname):
     context = sslopt.get('context', None)
     if not context:
         context = ssl.SSLContext(sslopt.get('ssl_version', ssl.PROTOCOL_TLS_CLIENT))
+        # Non default context need to manually enable SSLKEYLOGFILE support by setting the keylog_filename attribute.
+        # For more details see also:
+        # * https://docs.python.org/3.8/library/ssl.html?highlight=sslkeylogfile#context-creation
+        # * https://docs.python.org/3.8/library/ssl.html?highlight=sslkeylogfile#ssl.SSLContext.keylog_filename
+        context.keylog_filename = os.environ.get("SSLKEYLOGFILE", None)
 
         if sslopt.get('cert_reqs', ssl.CERT_NONE) != ssl.CERT_NONE:
             cafile = sslopt.get('ca_certs', None)

--- a/websocket/_http.py
+++ b/websocket/_http.py
@@ -19,7 +19,6 @@ limitations under the License.
 import errno
 import os
 import socket
-import sys
 
 from ._exceptions import *
 from ._logging import *


### PR DESCRIPTION
Hi @ all,

Thanks for maintaining and providing this library, appreciate it! 👍 

Recently I have been debugging some protocol on top of `websockets`. The client I have been debugging
was using this library for it's `websocket` communication. This is why I stumbled upon the fact, that
the `SSLKEYLOGFILE` will be not supported in all cases when using this library.
I am aware that one always can pass a completely custom SSLContext, but I am not 100% sure if that should 
be required here. Happy to get some feedback on this from the maintainers.

# Summary
`Python >= 3.8` supports `SSLKEYLOGFILE` for debugging, [see here](https://github.com/python/cpython/issues/78452).
Which is a very helpful feature for debugging SSL/TLS connections without disabling it.

## What is this good for?
The `SSLKEYLOGFILE` can be used to dump `TLS` session keys to a file which enables the user to decrypt the `TLS` traffic. This has the "advantage" that an actual `TLS` secured connection can be debugged, rather than a connection
where `TLS` is disabled. In some scenarios, connecting without TLS may not even be possible. 

## See also
* [CURL-SSLKEYLOGFILE](https://everything.curl.dev/usingcurl/tls/sslkeylogfile)
* [Wireshark - tls-decryption](https://wiki.wireshark.org/TLS#tls-decryption)
* [Python - SSLKEYLOGFILE](https://docs.python.org/3.8/library/ssl.html?highlight=sslkeylogfile#context-creation)

I hope the provided information is sufficient. 

best
Nico