### PR TITLE
Fix type annotations in the with str | bytes

### DIFF
--- a/websocket/_core.py
+++ b/websocket/_core.py
@@ -324,7 +324,7 @@ class WebSocket:
         """
         return self.send(payload, ABNF.OPCODE_BINARY)
 
-    def ping(self, payload: str or bytes = ""):
+    def ping(self, payload: str | bytes = ""):
         """
         Send ping data.
 
@@ -337,7 +337,7 @@ class WebSocket:
             payload = payload.encode("utf-8")
         self.send(payload, ABNF.OPCODE_PING)
 
-    def pong(self, payload: str or bytes = ""):
+    def pong(self, payload: str | bytes = ""):
         """
         Send pong data.
 
@@ -350,7 +350,7 @@ class WebSocket:
             payload = payload.encode("utf-8")
         self.send(payload, ABNF.OPCODE_PONG)
 
-    def recv(self) -> str or bytes:
+    def recv(self) -> str | bytes:
         """
         Receive string data(byte array) from the server.
 
@@ -521,7 +521,7 @@ class WebSocket:
             self.sock = None
             self.connected = False
 
-    def _send(self, data: str or bytes):
+    def _send(self, data: str | bytes):
         return send(self.sock, data)
 
     def _recv(self, bufsize):


### PR DESCRIPTION
I've faced an issue with Mypy that it complains about passing string to the ws.send() method. And found that you use bytes or str instead of the Python built-in pipe to be `str | bytes`.

Checked with Mypy and it works fine now.