### PR TITLE
Update _app import for type checkers

### DIFF
--- a/websocket/__init__.py
+++ b/websocket/__init__.py
@@ -17,7 +17,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from ._abnf import *
-from ._app import WebSocketApp, setReconnect
+from ._app import WebSocketApp as WebSocketApp, setReconnect as setReconnect
 from ._core import *
 from ._exceptions import *
 from ._logging import *


### PR DESCRIPTION
Pylint does comlains when importing WebSocketApp from websocket  with:

> "WebSocketApp" is not exported from module "websocket"
>  Import from "websocket._app" instead Pylance([reportPrivateImportUsage](https://github.com/microsoft/pyright/blob/main/docs/configuration.md#reportPrivateImportUsage))

To make type checkers happy, I updated the import..