### PR TITLE
on_reconnect callback

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -503,7 +503,7 @@ class WebSocketApp:
                 if self.ping_interval:
                     self._start_ping_thread()
 
-                if reconnecting:
+                if reconnecting and self.on_reconnect:
                     self._callback(self.on_reconnect)
                 else:
                     self._callback(self.on_open)

--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -432,6 +432,7 @@ class WebSocketApp:
         self.ping_interval = ping_interval
         self.ping_timeout = ping_timeout
         self.ping_payload = ping_payload
+        self.has_done_teardown = False
         self.keep_running = True
 
         def teardown(close_frame: ABNF = None):

--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -167,6 +167,7 @@ class WebSocketApp:
         url: str,
         header: Union[list, dict, Callable, None] = None,
         on_open: Optional[Callable[[WebSocket], None]] = None,
+        on_reconnect: Optional[Callable[[WebSocket], None]] = None,
         on_message: Optional[Callable[[WebSocket, Any], None]] = None,
         on_error: Optional[Callable[[WebSocket, Any], None]] = None,
         on_close: Optional[Callable[[WebSocket, Any, Any], None]] = None,
@@ -195,6 +196,10 @@ class WebSocketApp:
         on_open: function
             Callback object which is called at opening websocket.
             on_open has one argument.
+            The 1st argument is this class object.
+        on_reconnect: function
+            Callback object which is called at reconnecting websocket.
+            on_reconnect has one argument.
             The 1st argument is this class object.
         on_message: function
             Callback object which is called when received data.
@@ -246,6 +251,7 @@ class WebSocketApp:
         self.cookie = cookie
 
         self.on_open = on_open
+        self.on_reconnect = on_reconnect
         self.on_message = on_message
         self.on_data = on_data
         self.on_error = on_error
@@ -497,7 +503,10 @@ class WebSocketApp:
                 if self.ping_interval:
                     self._start_ping_thread()
 
-                self._callback(self.on_open)
+                if reconnecting:
+                    self._callback(self.on_reconnect)
+                else:
+                    self._callback(self.on_open)
 
                 dispatcher.read(self.sock.sock, read, check)
             except (


### PR DESCRIPTION
Ticket 971 (https://github.com/websocket-client/websocket-client/issues/971) discusses an ambiguity in our callback system between the connection opening for the first time and subsequent automatic reconnects.

To address this, this PR adds support for an on_reconnect callback. The on_reconnect callback (instead of the on_open callback) is called from setSock() on a reconnect. If no on_reconnect callback is provided, the previous behavior (of calling on_open on a reconnect) is preserved.

Ticket 974 (https://github.com/websocket-client/websocket-client/issues/974) involves the somewhat related case of WebSocketApp reuse after the server _intentionally_ disconnects. @GooVincent identified the solution, setting has_done_teardown to False.