### PR TITLE
Do not teardown when opcode=8 and reconnect

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -535,7 +535,7 @@ class WebSocketApp:
                 else:
                     raise e
 
-            if op_code == ABNF.OPCODE_CLOSE:
+            if op_code == ABNF.OPCODE_CLOSE and not reconnect:
                 return teardown(frame)
             elif op_code == ABNF.OPCODE_PING:
                 self._callback(self.on_ping, frame.data)


### PR DESCRIPTION
In addressing the issue opened at https://github.com/websocket-client/websocket-client/issues/976, 

it was noted that reconnection fails to establish when the server sends a close message. Therefore, 

I suggest not invoking the teardown process when the reconnect parameter is active.
