### PR TITLE
Asyncpong

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -501,7 +501,7 @@ class WebSocketApp:
         custom_dispatcher = bool(dispatcher)
         dispatcher = self.create_dispatcher(
             ping_timeout, dispatcher, parse_url(self.url)[3],
-            lambda : handleDisconnect(WebSocketConnectionClosedException, bool(reconnect))
+            lambda e : handleDisconnect(WebSocketConnectionClosedException(e), bool(reconnect))
         )
 
         try:

--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -468,7 +468,7 @@ class WebSocketApp:
                     )
                 ):
                     raise WebSocketTimeoutException("ping/pong timed out")
-            return TruehandleDisco
+            return True
 
         def closed(
             e: Union[

--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -481,7 +481,7 @@ class WebSocketApp:
                 fire_cont_frame=self.on_cont_message is not None,
                 skip_utf8_validation=skip_utf8_validation,
                 enable_multithread=True,
-                dispatcher: dispatcher,
+                dispatcher=dispatcher,
             )
 
             self.sock.settimeout(getdefaulttimeout())

--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -429,7 +429,7 @@ class WebSocketApp:
                     raise e
 
             if op_code == ABNF.OPCODE_CLOSE:
-                return teardown(frame)
+                return closed(frame)
             elif op_code == ABNF.OPCODE_PING:
                 self._callback(self.on_ping, frame.data)
             elif op_code == ABNF.OPCODE_PONG:

--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -229,6 +229,9 @@ class WebSocketApp:
                 except Exception as e:
                     _logging.debug(f"Failed to send ping: {e}")
 
+    def ready(self):
+        return self.sock and self.sock.connected
+
     def run_forever(
         self,
         sockopt: tuple = None,

--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -468,7 +468,21 @@ class WebSocketApp:
                     )
                 ):
                     raise WebSocketTimeoutException("ping/pong timed out")
-            return True
+            return TruehandleDisco
+
+        def closed(
+            e: Union[
+                WebSocketConnectionClosedException,
+                ConnectionRefusedError,
+                KeyboardInterrupt,
+                SystemExit,
+                Exception,
+                str,
+            ] = "closed unexpectedly"
+        ) -> bool:
+            if type(e) == str:
+                e = WebSocketConnectionClosedException(e)
+            return handleDisconnect(e, bool(reconnect))
 
         def handleDisconnect(
             e: Union[
@@ -502,10 +516,8 @@ class WebSocketApp:
                 teardown()
 
         custom_dispatcher = bool(dispatcher)
-        dispatcher = self.create_dispatcher(
-            ping_timeout, dispatcher, parse_url(self.url)[3],
-            lambda e : handleDisconnect(WebSocketConnectionClosedException(e), bool(reconnect))
-        )
+        dispatcher = self.create_dispatcher(ping_timeout,
+            dispatcher, parse_url(self.url)[3], closed)
 
         try:
             setSock()

--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -70,6 +70,9 @@ class DispatcherBase:
             _logging.info(f"User exited {e}")
             raise e
 
+    def write(self, sock: socket.socket, write_callback: Callable) -> None:
+        write_callback()
+
 
 class Dispatcher(DispatcherBase):
     """
@@ -92,7 +95,6 @@ class Dispatcher(DispatcherBase):
                 check_callback()
         finally:
             sel.close()
-
 
 class SSLDispatcher(DispatcherBase):
     """
@@ -149,6 +151,9 @@ class WrappedDispatcher:
     ) -> None:
         self.dispatcher.read(sock, read_callback)
         self.ping_timeout and self.timeout(self.ping_timeout, check_callback)
+
+    def write(self, sock: socket.socket, write_callback: Callable) -> None:
+        self.dispatcher.write(sock, write_callback)
 
     def timeout(self, seconds: float, callback: Callable) -> None:
         self.dispatcher.timeout(seconds, callback)
@@ -476,6 +481,7 @@ class WebSocketApp:
                 fire_cont_frame=self.on_cont_message is not None,
                 skip_utf8_validation=skip_utf8_validation,
                 enable_multithread=True,
+                dispatcher: dispatcher,
             )
 
             self.sock.settimeout(getdefaulttimeout())

--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -16,6 +16,7 @@ from ._exceptions import (
 )
 from ._ssl_compat import SSLEOFError
 from ._url import parse_url
+from ._dispatcher import *
 
 """
 _app.py
@@ -44,122 +45,6 @@ RECONNECT = 0
 def setReconnect(reconnectInterval: int) -> None:
     global RECONNECT
     RECONNECT = reconnectInterval
-
-
-class DispatcherBase:
-    """
-    DispatcherBase
-    """
-
-    def __init__(self, app: Any, ping_timeout: Union[float, int, None]) -> None:
-        self.app = app
-        self.ping_timeout = ping_timeout
-
-    def timeout(self, seconds: Union[float, int, None], callback: Callable) -> None:
-        time.sleep(seconds)
-        callback()
-
-    def reconnect(self, seconds: int, reconnector: Callable) -> None:
-        try:
-            _logging.info(
-                f"reconnect() - retrying in {seconds} seconds [{len(inspect.stack())} frames in stack]"
-            )
-            time.sleep(seconds)
-            reconnector(reconnecting=True)
-        except KeyboardInterrupt as e:
-            _logging.info(f"User exited {e}")
-            raise e
-
-    def write(self, sock: socket.socket, write_callback: Callable) -> None:
-        write_callback()
-
-
-class Dispatcher(DispatcherBase):
-    """
-    Dispatcher
-    """
-
-    def read(
-        self,
-        sock: socket.socket,
-        read_callback: Callable,
-        check_callback: Callable,
-    ) -> None:
-        sel = selectors.DefaultSelector()
-        sel.register(self.app.sock.sock, selectors.EVENT_READ)
-        try:
-            while self.app.keep_running:
-                if sel.select(self.ping_timeout):
-                    if not read_callback():
-                        break
-                check_callback()
-        finally:
-            sel.close()
-
-class SSLDispatcher(DispatcherBase):
-    """
-    SSLDispatcher
-    """
-
-    def read(
-        self,
-        sock: socket.socket,
-        read_callback: Callable,
-        check_callback: Callable,
-    ) -> None:
-        sock = self.app.sock.sock
-        sel = selectors.DefaultSelector()
-        sel.register(sock, selectors.EVENT_READ)
-        try:
-            while self.app.keep_running:
-                if self.select(sock, sel):
-                    if not read_callback():
-                        break
-                check_callback()
-        finally:
-            sel.close()
-
-    def select(self, sock, sel: selectors.DefaultSelector):
-        sock = self.app.sock.sock
-        if sock.pending():
-            return [
-                sock,
-            ]
-
-        r = sel.select(self.ping_timeout)
-
-        if len(r) > 0:
-            return r[0][0]
-
-
-class WrappedDispatcher:
-    """
-    WrappedDispatcher
-    """
-
-    def __init__(self, app, ping_timeout: Union[float, int, None], dispatcher) -> None:
-        self.app = app
-        self.ping_timeout = ping_timeout
-        self.dispatcher = dispatcher
-        dispatcher.signal(2, dispatcher.abort)  # keyboard interrupt
-
-    def read(
-        self,
-        sock: socket.socket,
-        read_callback: Callable,
-        check_callback: Callable,
-    ) -> None:
-        self.dispatcher.read(sock, read_callback)
-        self.ping_timeout and self.timeout(self.ping_timeout, check_callback)
-
-    def write(self, sock: socket.socket, write_callback: Callable) -> None:
-        self.dispatcher.write(sock, write_callback)
-
-    def timeout(self, seconds: float, callback: Callable) -> None:
-        self.dispatcher.timeout(seconds, callback)
-
-    def reconnect(self, seconds: int, reconnector: Callable) -> None:
-        self.timeout(seconds, reconnector)
 
 
 class WebSocketApp:

--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -501,7 +501,8 @@ class WebSocketApp:
 
         custom_dispatcher = bool(dispatcher)
         dispatcher = self.create_dispatcher(
-            ping_timeout, dispatcher, parse_url(self.url)[3]
+            ping_timeout, dispatcher, parse_url(self.url)[3],
+            lambda : handleDisconnect(WebSocketConnectionClosedException, bool(reconnect))
         )
 
         try:
@@ -527,9 +528,10 @@ class WebSocketApp:
         ping_timeout: Union[float, int, None],
         dispatcher: Optional[DispatcherBase] = None,
         is_ssl: bool = False,
+        handleDisconnect: Callable = None,
     ) -> Union[Dispatcher, SSLDispatcher, WrappedDispatcher]:
         if dispatcher:  # If custom dispatcher is set, use WrappedDispatcher
-            return WrappedDispatcher(self, ping_timeout, dispatcher)
+            return WrappedDispatcher(self, ping_timeout, dispatcher, handleDisconnect)
         timeout = ping_timeout or 10
         if is_ssl:
             return SSLDispatcher(self, timeout)

--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -424,7 +424,7 @@ class WebSocketApp:
                 SSLEOFError,
             ) as e:
                 if custom_dispatcher:
-                    return handleDisconnect(e, bool(reconnect))
+                    return closed(e)
                 else:
                     raise e
 

--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -480,7 +480,7 @@ class WebSocketApp:
                 str,
             ] = "closed unexpectedly"
         ) -> bool:
-            if type(e) == str:
+            if type(e) is str:
                 e = WebSocketConnectionClosedException(e)
             return handleDisconnect(e, bool(reconnect))
 
@@ -516,8 +516,9 @@ class WebSocketApp:
                 teardown()
 
         custom_dispatcher = bool(dispatcher)
-        dispatcher = self.create_dispatcher(ping_timeout,
-            dispatcher, parse_url(self.url)[3], closed)
+        dispatcher = self.create_dispatcher(
+            ping_timeout, dispatcher, parse_url(self.url)[3], closed
+        )
 
         try:
             setSock()

--- a/websocket/_core.py
+++ b/websocket/_core.py
@@ -10,7 +10,7 @@ from ._exceptions import WebSocketProtocolException, WebSocketConnectionClosedEx
 from ._handshake import SUPPORTED_REDIRECT_STATUSES, handshake
 from ._http import connect, proxy_info
 from ._logging import debug, error, trace, isEnabledForError, isEnabledForTrace
-from ._socket import getdefaulttimeout, recv, sock_opt
+from ._socket import getdefaulttimeout, recv, send, sock_opt
 from ._ssl_compat import ssl
 from ._utils import NoLock
 from ._dispatcher import DispatcherBase, WrappedDispatcher
@@ -559,7 +559,9 @@ class WebSocket:
             self.connected = False
 
     def _send(self, data: Union[str, bytes]):
-        return self.dispatcher.send(self.sock, data)
+        if self.dispatcher:
+            return self.dispatcher.send(self.sock, data)
+        return send(self.sock, data)
 
     def _recv(self, bufsize):
         try:

--- a/websocket/_core.py
+++ b/websocket/_core.py
@@ -13,6 +13,7 @@ from ._logging import debug, error, trace, isEnabledForError, isEnabledForTrace
 from ._socket import getdefaulttimeout, recv, send, sock_opt
 from ._ssl_compat import ssl
 from ._utils import NoLock
+from ._app import DispatcherBase
 
 """
 _core.py
@@ -82,6 +83,7 @@ class WebSocket:
         fire_cont_frame: bool = False,
         enable_multithread: bool = True,
         skip_utf8_validation: bool = False,
+        dispatcher: DispatcherBase = None,
         **_,
     ):
         """
@@ -101,6 +103,7 @@ class WebSocket:
         # These buffer over the build-up of a single frame.
         self.frame_buffer = frame_buffer(self._recv, skip_utf8_validation)
         self.cont_frame = continuous_frame(fire_cont_frame, skip_utf8_validation)
+        self.dispatcher = dispatcher
 
         if enable_multithread:
             self.lock = threading.Lock()
@@ -374,7 +377,7 @@ class WebSocket:
         """
         if isinstance(payload, str):
             payload = payload.encode("utf-8")
-        self.send(payload, ABNF.OPCODE_PONG)
+        self.dispatcher.write(self.sock, lambda : self.send(payload, ABNF.OPCODE_PONG))
 
     def recv(self) -> Union[str, bytes]:
         """

--- a/websocket/_core.py
+++ b/websocket/_core.py
@@ -13,7 +13,7 @@ from ._logging import debug, error, trace, isEnabledForError, isEnabledForTrace
 from ._socket import getdefaulttimeout, recv, send, sock_opt
 from ._ssl_compat import ssl
 from ._utils import NoLock
-from ._app import DispatcherBase
+from ._dispatcher import DispatcherBase, WrappedDispatcher
 
 """
 _core.py
@@ -83,7 +83,7 @@ class WebSocket:
         fire_cont_frame: bool = False,
         enable_multithread: bool = True,
         skip_utf8_validation: bool = False,
-        dispatcher: DispatcherBase = None,
+        dispatcher: Union[DispatcherBase, WrappedDispatcher] = None,
         **_,
     ):
         """

--- a/websocket/_core.py
+++ b/websocket/_core.py
@@ -10,7 +10,7 @@ from ._exceptions import WebSocketProtocolException, WebSocketConnectionClosedEx
 from ._handshake import SUPPORTED_REDIRECT_STATUSES, handshake
 from ._http import connect, proxy_info
 from ._logging import debug, error, trace, isEnabledForError, isEnabledForTrace
-from ._socket import getdefaulttimeout, recv, send, sock_opt
+from ._socket import getdefaulttimeout, recv, sock_opt
 from ._ssl_compat import ssl
 from ._utils import NoLock
 from ._dispatcher import DispatcherBase, WrappedDispatcher
@@ -377,7 +377,7 @@ class WebSocket:
         """
         if isinstance(payload, str):
             payload = payload.encode("utf-8")
-        self.dispatcher.write(self.sock, lambda : self.send(payload, ABNF.OPCODE_PONG))
+        self.send(payload, ABNF.OPCODE_PONG)
 
     def recv(self) -> Union[str, bytes]:
         """
@@ -559,7 +559,7 @@ class WebSocket:
             self.connected = False
 
     def _send(self, data: Union[str, bytes]):
-        return send(self.sock, data)
+        return self.dispatcher.send(self.sock, data)
 
     def _recv(self, bufsize):
         try:

--- a/websocket/_dispatcher.py
+++ b/websocket/_dispatcher.py
@@ -110,7 +110,7 @@ class WrappedDispatcher:
         self.ping_timeout and self.timeout(self.ping_timeout, check_callback)
 
     def send(self, sock: socket.socket, data: Union[str, bytes]) -> None:
-        self.dispatcher.buffwrite(sock, lambda : send(sock, data))
+        self.dispatcher.buffwrite(sock, data, send)
         return len(data)
 
     def timeout(self, seconds: float, callback: Callable) -> None:

--- a/websocket/_dispatcher.py
+++ b/websocket/_dispatcher.py
@@ -99,7 +99,9 @@ class WrappedDispatcher:
     WrappedDispatcher
     """
 
-    def __init__(self, app, ping_timeout: Union[float, int, None], dispatcher, handleDisconnect) -> None:
+    def __init__(
+        self, app, ping_timeout: Union[float, int, None], dispatcher, handleDisconnect
+    ) -> None:
         self.app = app
         self.ping_timeout = ping_timeout
         self.dispatcher = dispatcher

--- a/websocket/_dispatcher.py
+++ b/websocket/_dispatcher.py
@@ -1,7 +1,11 @@
-import time, selectors, socket
+import time
+import socket
+import inspect
+import selectors
 from typing import Any, Callable, Optional, Union
 from . import _logging
 from ._socket import send
+
 
 class DispatcherBase:
     """
@@ -52,6 +56,7 @@ class Dispatcher(DispatcherBase):
                 check_callback()
         finally:
             sel.close()
+
 
 class SSLDispatcher(DispatcherBase):
     """

--- a/websocket/_dispatcher.py
+++ b/websocket/_dispatcher.py
@@ -94,10 +94,11 @@ class WrappedDispatcher:
     WrappedDispatcher
     """
 
-    def __init__(self, app, ping_timeout: Union[float, int, None], dispatcher) -> None:
+    def __init__(self, app, ping_timeout: Union[float, int, None], dispatcher, handleDisconnect) -> None:
         self.app = app
         self.ping_timeout = ping_timeout
         self.dispatcher = dispatcher
+        self.handleDisconnect = handleDisconnect
         dispatcher.signal(2, dispatcher.abort)  # keyboard interrupt
 
     def read(
@@ -110,7 +111,7 @@ class WrappedDispatcher:
         self.ping_timeout and self.timeout(self.ping_timeout, check_callback)
 
     def send(self, sock: socket.socket, data: Union[str, bytes]) -> None:
-        self.dispatcher.buffwrite(sock, data, send)
+        self.dispatcher.buffwrite(sock, data, send, self.handleDisconnect)
         return len(data)
 
     def timeout(self, seconds: float, callback: Callable) -> None:

--- a/websocket/_dispatcher.py
+++ b/websocket/_dispatcher.py
@@ -114,8 +114,8 @@ class WrappedDispatcher:
         self.dispatcher.buffwrite(sock, data, send, self.handleDisconnect)
         return len(data)
 
-    def timeout(self, seconds: float, callback: Callable) -> None:
-        self.dispatcher.timeout(seconds, callback)
+    def timeout(self, seconds: float, callback: Callable, *args) -> None:
+        self.dispatcher.timeout(seconds, callback, *args)
 
     def reconnect(self, seconds: int, reconnector: Callable) -> None:
         self.timeout(seconds, reconnector, True)

--- a/websocket/_dispatcher.py
+++ b/websocket/_dispatcher.py
@@ -1,6 +1,7 @@
 import time, selectors, socket
 from typing import Any, Callable, Optional, Union
 from . import _logging
+from ._socket import send
 
 class DispatcherBase:
     """
@@ -26,8 +27,8 @@ class DispatcherBase:
             _logging.info(f"User exited {e}")
             raise e
 
-    def write(self, sock: socket.socket, write_callback: Callable) -> None:
-        write_callback()
+    def send(self, sock: socket.socket, data: Union[str, bytes]) -> None:
+        return send(sock, data)
 
 
 class Dispatcher(DispatcherBase):
@@ -108,8 +109,9 @@ class WrappedDispatcher:
         self.dispatcher.read(sock, read_callback)
         self.ping_timeout and self.timeout(self.ping_timeout, check_callback)
 
-    def write(self, sock: socket.socket, write_callback: Callable) -> None:
-        self.dispatcher.write(sock, write_callback)
+    def send(self, sock: socket.socket, data: Union[str, bytes]) -> None:
+        self.dispatcher.buffwrite(sock, lambda : send(sock, data))
+        return len(data)
 
     def timeout(self, seconds: float, callback: Callable) -> None:
         self.dispatcher.timeout(seconds, callback)

--- a/websocket/_dispatcher.py
+++ b/websocket/_dispatcher.py
@@ -118,4 +118,4 @@ class WrappedDispatcher:
         self.dispatcher.timeout(seconds, callback)
 
     def reconnect(self, seconds: int, reconnector: Callable) -> None:
-        self.timeout(seconds, reconnector)
+        self.timeout(seconds, reconnector, True)

--- a/websocket/_dispatcher.py
+++ b/websocket/_dispatcher.py
@@ -1,0 +1,118 @@
+import time, selectors, socket
+from typing import Any, Callable, Optional, Union
+from . import _logging
+
+class DispatcherBase:
+    """
+    DispatcherBase
+    """
+
+    def __init__(self, app: Any, ping_timeout: Union[float, int, None]) -> None:
+        self.app = app
+        self.ping_timeout = ping_timeout
+
+    def timeout(self, seconds: Union[float, int, None], callback: Callable) -> None:
+        time.sleep(seconds)
+        callback()
+
+    def reconnect(self, seconds: int, reconnector: Callable) -> None:
+        try:
+            _logging.info(
+                f"reconnect() - retrying in {seconds} seconds [{len(inspect.stack())} frames in stack]"
+            )
+            time.sleep(seconds)
+            reconnector(reconnecting=True)
+        except KeyboardInterrupt as e:
+            _logging.info(f"User exited {e}")
+            raise e
+
+    def write(self, sock: socket.socket, write_callback: Callable) -> None:
+        write_callback()
+
+
+class Dispatcher(DispatcherBase):
+    """
+    Dispatcher
+    """
+
+    def read(
+        self,
+        sock: socket.socket,
+        read_callback: Callable,
+        check_callback: Callable,
+    ) -> None:
+        sel = selectors.DefaultSelector()
+        sel.register(self.app.sock.sock, selectors.EVENT_READ)
+        try:
+            while self.app.keep_running:
+                if sel.select(self.ping_timeout):
+                    if not read_callback():
+                        break
+                check_callback()
+        finally:
+            sel.close()
+
+class SSLDispatcher(DispatcherBase):
+    """
+    SSLDispatcher
+    """
+
+    def read(
+        self,
+        sock: socket.socket,
+        read_callback: Callable,
+        check_callback: Callable,
+    ) -> None:
+        sock = self.app.sock.sock
+        sel = selectors.DefaultSelector()
+        sel.register(sock, selectors.EVENT_READ)
+        try:
+            while self.app.keep_running:
+                if self.select(sock, sel):
+                    if not read_callback():
+                        break
+                check_callback()
+        finally:
+            sel.close()
+
+    def select(self, sock, sel: selectors.DefaultSelector):
+        sock = self.app.sock.sock
+        if sock.pending():
+            return [
+                sock,
+            ]
+
+        r = sel.select(self.ping_timeout)
+
+        if len(r) > 0:
+            return r[0][0]
+
+
+class WrappedDispatcher:
+    """
+    WrappedDispatcher
+    """
+
+    def __init__(self, app, ping_timeout: Union[float, int, None], dispatcher) -> None:
+        self.app = app
+        self.ping_timeout = ping_timeout
+        self.dispatcher = dispatcher
+        dispatcher.signal(2, dispatcher.abort)  # keyboard interrupt
+
+    def read(
+        self,
+        sock: socket.socket,
+        read_callback: Callable,
+        check_callback: Callable,
+    ) -> None:
+        self.dispatcher.read(sock, read_callback)
+        self.ping_timeout and self.timeout(self.ping_timeout, check_callback)
+
+    def write(self, sock: socket.socket, write_callback: Callable) -> None:
+        self.dispatcher.write(sock, write_callback)
+
+    def timeout(self, seconds: float, callback: Callable) -> None:
+        self.dispatcher.timeout(seconds, callback)
+
+    def reconnect(self, seconds: int, reconnector: Callable) -> None:
+        self.timeout(seconds, reconnector)

--- a/websocket/_socket.py
+++ b/websocket/_socket.py
@@ -7,7 +7,7 @@ from ._exceptions import (
     WebSocketConnectionClosedException,
     WebSocketTimeoutException,
 )
-from ._ssl_compat import SSLError, SSLWantReadError, SSLWantWriteError
+from ._ssl_compat import SSLError, SSLEOFError, SSLWantReadError, SSLWantWriteError
 from ._utils import extract_error_code, extract_err_message
 
 """
@@ -154,6 +154,8 @@ def send(sock: socket.socket, data: Union[bytes, str]) -> int:
     def _send():
         try:
             return sock.send(data)
+        except SSLEOFError:
+            raise WebSocketConnectionClosedException("socket is already closed.")
         except SSLWantWriteError:
             pass
         except socket.error as exc:


### PR DESCRIPTION
This PR consists of a few things, with the general intention of improving asynchronous writes and reconnect behavior.

TL/DR: fixes https://github.com/websocket-client/websocket-client/issues/976 and https://github.com/websocket-client/websocket-client/issues/942 and https://github.com/websocket-client/websocket-client/issues/974

background
----------
Running asynchronously (with rel dispatcher), I noticed a couple things.

Firstly, I was seeing an error (SSLEOFError) that occasionally occurred in the course of a write, in particular while sending a PONG (hence the name of this branch). I actually think I saw some ticket about this a while ago, but wasn't able to reproduce it at the time.

Secondly, I noticed that my on_reconnect callback wasn't being fired, and that reconnects weren't reliable - I had to handle some cases in an on_error handler.

reconnects
----------
The reconnect-related fix is in WrappedDispatcher: the problem was that reconnect() (by way of timeout()) wasn't passing True (as reconnecting kwarg) to setSock(); I modified reconnect() and timeout() to address this - problem solved.

async writes
------------
I figured this was happening due to my asynchronous usage of the socket - it was probably trying to write when there wasn't room in the write buffer or writes weren't available for some other reason. For reference, WebSocket.send_frame() (in the _core module, on line 340) is where an individual frame is sent.

The fix is to write asynchronously in custom dispatcher / async mode. I modified WebSocket._send() (line 562) to use the send() function on the dispatcher. DispatcherBase now has a send() function, which just calls _socket.send() (as WebSocket._send() did previously - so there is no change with the default sync dispatcher). WrappedDispatcher.send() uses dispatcher.buffwrite(), which is available in the latest version (0.4.9.17) of rel. The WebSocket constructor now takes a dispatcher kwarg, and saves it on self.

Back in the _app module, in WebSocketApp, create_dispatcher() takes a handleDisconnect kwarg, which is passed to WrappedDispatcher. Also in run_forever(): handleDisconnect(WebSocketConnectionClosedException, bool(reconnect)) lambda is passed (as handleDisconnect kwarg) to create_dispatcher() (which WrappedDispatcher.send() passes to buffwrite()); and setSock() passes the dispatcher to the WebSocket instance.

why the _dispatcher module?
--------------------------
I moved DispatcherBase, Dispatcher, SSLDispatcher, and WrappedDispatcher to the new _dispatcher module so that the _core module could non-circularly import DispatcherBase and WrappedDispatcher for the dispatcher kwarg type hint in the WebSocket constructor.

status
------
This is still something of a work in progress. I've been testing this branch, and for my use case it's performing better than the current master branch, but further testing would be a good idea.

Please test with your use case and LMK how it goes!