### PR TITLE
no default NO_PROXY list

### DIFF
--- a/websocket/_url.py
+++ b/websocket/_url.py
@@ -73,9 +73,6 @@ def parse_url(url: str) -> tuple:
     return hostname, port, resource, is_secure
 
 
-DEFAULT_NO_PROXY_HOST = ["localhost", "127.0.0.1"]
-
-
 def _is_ip_address(addr: str) -> bool:
     try:
         socket.inet_aton(addr)
@@ -108,8 +105,9 @@ def _is_no_proxy_host(hostname: str, no_proxy: Optional[list]) -> bool:
             " ", ""
         ):
             no_proxy = v.split(",")
+
     if not no_proxy:
-        no_proxy = DEFAULT_NO_PROXY_HOST
+        no_proxy = []
 
     if "*" in no_proxy:
         return True


### PR DESCRIPTION
This change removes `localhost` and `127.0.0.1` from the default list of domains to exempt from a proxy. Client's who require this feature can set it themselves.

### why

- A library providing low-level access to API to WebSockets should not set unnecessary defaults.
- I don't think that it is something that is generally expected to be the default behavior.
- Client's who want to ignore localhost addresses can set the lists themselves.
- Users have to explicitly set NO_PROXY to an empty list instead to allow proxying of localhost - this seems a bit clunky to me, leaving the list empty is the more natural choice.
- It is not documented.

---

If you choose to keep the defaults, I believe that it should be better documented. `websocket._url.get_proxy_info` and `websocket._app.WebSocketApp.run_forever` set the default no_proxy list to None, `websocket._core.WebSocket`  doesn't specify the default either. This gives the false impression that the default is empty. If you choose to keep `localhost` in the default no_proxy list, I believe that it should be documented in all of these places.