### PR TITLE
Correctly type `sock_opt.__init__` parameters and `sock_opt.timeout`

### DIFF
--- a/websocket/_socket.py
+++ b/websocket/_socket.py
@@ -1,7 +1,7 @@
 import errno
 import selectors
 import socket
-from typing import Union
+from typing import Optional, Union
 
 from ._exceptions import (
     WebSocketConnectionClosedException,
@@ -53,14 +53,14 @@ __all__ = [
 
 
 class sock_opt:
-    def __init__(self, sockopt: list, sslopt: dict) -> None:
+    def __init__(self, sockopt: Optional[list], sslopt: Optional[dict]) -> None:
         if sockopt is None:
             sockopt = []
         if sslopt is None:
             sslopt = {}
         self.sockopt = sockopt
         self.sslopt = sslopt
-        self.timeout = None
+        self.timeout: Union[int, float, None] = None
 
 
 def setdefaulttimeout(timeout: Union[int, float, None]) -> None:


### PR DESCRIPTION
### Problem
The type hints of the parameters in [`sock_opt.__init__`](https://github.com/websocket-client/websocket-client/blob/77337ef76f1f38b14742ab28309f9ca51b8fb011/websocket/_socket.py#L56) are not entirely correct since `None` is an acceptable value for both of them. This causes type checkers to inappropriately flag `sock_opt(None, None)`. Additionally, some type checkers flag any assignment to `sock_opt.timeout` since its type is inferred to be `None`.

### Solution
I have used `typing.Optional` to allow `None` to be passed to `sock_opt.__init__` without complaint, and I have typed `timeout` as `Union[int, float, None]` which appears in other places where it is used.

### Replication
I am using Pyright which comes with the Pylance extension in VS Code, but the problem can be reproduced with other common type checkers as well. Simply try
```python
sockopt = sock_opt(None, None)
sockopt.timeout = 10
```
and run through a type checker. Here are some of the common errors:
- **pyright**
  ```
  Argument of type "None" cannot be assigned to parameter "sockopt" of type "list[Unknown]" in function "__init__"
  "None" is incompatible with "list[Unknown]"
  Argument of type "None" cannot be assigned to parameter "sslopt" of type "dict[Unknown, Unknown]" in function "__init__"
  "None" is incompatible with "dict[Unknown, Unknown]"
  Cannot assign to attribute "timeout" for class "sock_opt"
  Expression of type "Literal[10]" cannot be assigned to attribute "timeout" of class "sock_opt"
    "Literal[10]" is incompatible with "None"
  ```
- **mypy**
  ```
  error: Argument 1 to "sock_opt" has incompatible type "None"; expected "list[Any]"  [arg-type]
  error: Argument 2 to "sock_opt" has incompatible type "None"; expected "dict[Any, Any]"  [arg-type]
  error: Incompatible types in assignment (expression has type "int", variable has type "None")  [assignment]
  ```
- **pytype**
  ```
  Function sock_opt.__init__ was called with the wrong arguments [wrong-arg-types]
         Expected: (self, sockopt: list, ...)
  Actually passed: (self, sockopt: None, ...)
  For more details, see https://google.github.io/pytype/errors.html#wrong-arg-types
  ```