### PR TITLE
Adding logic to allow the client to decide if the websocket frame mask should be used when sending messages.

### DIFF
--- a/websocket/_abnf.py
+++ b/websocket/_abnf.py
@@ -205,7 +205,7 @@ class ABNF:
         return f"fin={self.fin} opcode={self.opcode} data={self.data}"
 
     @staticmethod
-    def create_frame(data: Union[bytes, str], opcode: int, fin: int = 1) -> "ABNF":
+    def create_frame(data: Union[bytes, str], opcode: int, fin: int = 1, use_frame_mask: bool = True) -> "ABNF":
         """
         Create frame to send text, binary and other data.
 
@@ -219,11 +219,16 @@ class ABNF:
             operation code. please see OPCODE_MAP.
         fin: int
             fin flag. if set to 0, create continue fragmentation.
+        use_frame_mask: bool
+            Whether to mask the data in the websocket frame sent. Default is True.
         """
         if opcode == ABNF.OPCODE_TEXT and isinstance(data, str):
             data = data.encode("utf-8")
-        # mask must be set if send data from client
-        return ABNF(fin, 0, 0, 0, opcode, 1, data)
+        # From the websocket rfc, a mask must be set if send data from client.
+        # However, computing the mask adds a measurable amount of overhead and is unnecessary if SSL is being used to secure the connection.
+        # Most modern web servers will accept unmasked data when sent over SSL, thus making this optional can help performance.
+        mask_value = 1 if use_frame_mask else 0
+        return ABNF(fin, 0, 0, 0, opcode, mask_value, data)
 
     def format(self) -> bytes:
         """

--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -274,7 +274,7 @@ class WebSocketApp:
         self.has_done_teardown = False
         self.has_done_teardown_lock = threading.Lock()
 
-    def send(self, data: Union[bytes, str], opcode: int = ABNF.OPCODE_TEXT) -> None:
+    def send(self, data: Union[bytes, str], opcode: int = ABNF.OPCODE_TEXT, use_frame_mask: bool = True) -> None:
         """
         send message
 
@@ -285,9 +285,11 @@ class WebSocketApp:
             data must be utf-8 string or unicode.
         opcode: int
             Operation code of data. Default is OPCODE_TEXT.
+        use_frame_mask: bool
+            Whether to mask the data in the websocket frame sent. Default is True.
         """
 
-        if not self.sock or self.sock.send(data, opcode) == 0:
+        if not self.sock or self.sock.send(data, opcode, use_frame_mask) == 0:
             raise WebSocketConnectionClosedException("Connection is already closed.")
 
     def send_text(self, text_data: str) -> None:

--- a/websocket/_core.py
+++ b/websocket/_core.py
@@ -295,7 +295,7 @@ class WebSocket:
             Whether to mask the data in the websocket frame sent. Default is True.
         """
 
-        frame = ABNF.create_frame(payload, opcode, use_frame_mask)
+        frame = ABNF.create_frame(payload, opcode, use_frame_mask=use_frame_mask)
         return self.send_frame(frame)
 
     def send_text(self, text_data: str) -> int:

--- a/websocket/_core.py
+++ b/websocket/_core.py
@@ -279,7 +279,7 @@ class WebSocket:
                 self.sock = None
             raise
 
-    def send(self, payload: Union[bytes, str], opcode: int = ABNF.OPCODE_TEXT) -> int:
+    def send(self, payload: Union[bytes, str], opcode: int = ABNF.OPCODE_TEXT, use_frame_mask: bool = True) -> int:
         """
         Send the data as string.
 
@@ -291,9 +291,11 @@ class WebSocket:
             Otherwise, it must be string(byte array).
         opcode: int
             Operation code (opcode) to send.
+        use_frame_mask: bool
+            Whether to mask the data in the websocket frame sent. Default is True.
         """
 
-        frame = ABNF.create_frame(payload, opcode)
+        frame = ABNF.create_frame(payload, opcode, use_frame_mask)
         return self.send_frame(frame)
 
     def send_text(self, text_data: str) -> int:


### PR DESCRIPTION
After debugging perf issues on lower-end devices like a Pi4 and Pi3, I found that the WebSocket lib was performing a masking operation over the entire buffer sent, as the websocket standard requires. Unfortunately, that masking operation is quite costly; I measured that it doubled the amount of time required to send a ~10kb buffer. 

I looked into why the masking is done, and it was added due to the [security issue discussed in this paper](https://web.archive.org/web/20180127212141/http://w2spconf.com/2011/papers/websocket.pdf). The problem is that the paper was published in 2011 and deals with unencrypted web sockets. Since almost all internet traffic WebSockets now use SSL, there have been a [few attempts to remove the masking from the protocol](https://www.ietf.org/archive/id/draft-damjanovic-websockets-nomasking-00.html) since it adds overhead and isn't needed anymore.

I added a simple optional flag to the send call that defaults to masking enabled (as the standard requires), but it allows the client to disable the mask if desired. As I said above, if the client knows the websocket is opened via SSL or it's only being used on a local LAN, the mask is not needed. As I also said, skipping the mask resulted in dropping the send time by half and reducing the CPU percentage required by 10% in my application. 

From my testing, most modern web servers will accept client messages without masking, so this seems to be a helpful option for lower-end IOT devices.

If there are any questions, I would love to discuss them!