### PR TITLE
Use ipaddress module for no_proxy parsing

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -478,7 +478,7 @@ class WebSocketApp:
                 SystemExit,
                 Exception,
                 str,
-            ] = "closed unexpectedly"
+            ] = "closed unexpectedly",
         ) -> bool:
             if type(e) is str:
                 e = WebSocketConnectionClosedException(e)

--- a/websocket/_url.py
+++ b/websocket/_url.py
@@ -1,6 +1,5 @@
+import ipaddress
 import os
-import socket
-import struct
 from typing import Optional
 from urllib.parse import unquote, urlparse
 from ._exceptions import WebSocketProxyException
@@ -74,9 +73,11 @@ def parse_url(url: str) -> tuple:
 
 
 def _is_ip_address(addr: str) -> bool:
+    if not isinstance(addr, str):
+        raise TypeError("_is_ip_address() argument 1 must be str")
     try:
-        socket.inet_aton(addr)
-    except socket.error:
+        ipaddress.ip_address(addr)
+    except ValueError:
         return False
     else:
         return True
@@ -84,19 +85,18 @@ def _is_ip_address(addr: str) -> bool:
 
 def _is_subnet_address(hostname: str) -> bool:
     try:
-        addr, netmask = hostname.split("/")
-        return _is_ip_address(addr) and 0 <= int(netmask) < 32
+        ipaddress.ip_network(hostname)
     except ValueError:
         return False
+    else:
+        return True
 
 
 def _is_address_in_network(ip: str, net: str) -> bool:
-    ipaddr: int = struct.unpack("!I", socket.inet_aton(ip))[0]
-    netaddr, netmask = net.split("/")
-    netaddr: int = struct.unpack("!I", socket.inet_aton(netaddr))[0]
-
-    netmask = (0xFFFFFFFF << (32 - int(netmask))) & 0xFFFFFFFF
-    return ipaddr & netmask == netaddr
+    try:
+        return ipaddress.ip_network(ip).subnet_of(ipaddress.ip_network(net))
+    except TypeError:
+        return False
 
 
 def _is_no_proxy_host(hostname: str, no_proxy: Optional[list]) -> bool:

--- a/websocket/_url.py
+++ b/websocket/_url.py
@@ -122,7 +122,7 @@ def _is_no_proxy_host(hostname: str, no_proxy: Optional[list]) -> bool:
             ]
         )
     for domain in [domain for domain in no_proxy if domain.startswith(".")]:
-        endDomain = domain.lstrip('.')
+        endDomain = domain.lstrip(".")
         if hostname.endswith(endDomain):
             return True
     return False

--- a/websocket/tests/test_url.py
+++ b/websocket/tests/test_url.py
@@ -36,6 +36,8 @@ class UrlTest(unittest.TestCase):
         self.assertTrue(_is_address_in_network("127.0.0.1", "127.0.0.0/8"))
         self.assertTrue(_is_address_in_network("127.1.0.1", "127.0.0.0/8"))
         self.assertFalse(_is_address_in_network("127.1.0.1", "127.0.0.0/24"))
+        self.assertTrue(_is_address_in_network("2001:db8::1", "2001:db8::/64"))
+        self.assertFalse(_is_address_in_network("2001:db8:1::1", "2001:db8::/64"))
 
     def test_parse_url(self):
         p = parse_url("ws://www.example.com/r")
@@ -167,11 +169,16 @@ class IsNoProxyHostTest(unittest.TestCase):
         self.assertTrue(_is_no_proxy_host("127.0.0.1", ["127.0.0.0/8"]))
         self.assertTrue(_is_no_proxy_host("127.0.0.2", ["127.0.0.0/8"]))
         self.assertFalse(_is_no_proxy_host("127.1.0.1", ["127.0.0.0/24"]))
-        os.environ["no_proxy"] = "127.0.0.0/8"
+        self.assertTrue(_is_no_proxy_host("2001:db8::1", ["2001:db8::/64"]))
+        self.assertFalse(_is_no_proxy_host("2001:db8:1::1", ["2001:db8::/64"]))
+        os.environ["no_proxy"] = "127.0.0.0/8,2001:db8::/64"
         self.assertTrue(_is_no_proxy_host("127.0.0.1", None))
         self.assertTrue(_is_no_proxy_host("127.0.0.2", None))
-        os.environ["no_proxy"] = "127.0.0.0/24"
+        self.assertTrue(_is_no_proxy_host("2001:db8::1", None))
+        self.assertFalse(_is_no_proxy_host("2001:db8:1::1", None))
+        os.environ["no_proxy"] = "127.0.0.0/24,2001:db8::/64"
         self.assertFalse(_is_no_proxy_host("127.1.0.1", None))
+        self.assertFalse(_is_no_proxy_host("2001:db8:1::1", None))
 
     def test_hostname_match(self):
         self.assertTrue(_is_no_proxy_host("my.websocket.org", ["my.websocket.org"]))


### PR DESCRIPTION
This enables support for IPv6 CIDRs in the no_proxy option