### PR TITLE
Improve custom dispatcher error handling

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -469,6 +469,7 @@ class WebSocketApp:
                 WebSocketConnectionClosedException,
                 KeyboardInterrupt,
                 SSLEOFError,
+                ConnectionResetError,
             ) as e:
                 if custom_dispatcher:
                     return closed(e)


### PR DESCRIPTION
Add ConnectionResetError to improve custom dispatcher error handling when server kills connection.

Addresses issue mentioned in https://github.com/websocket-client/websocket-client/issues/541#issuecomment-4119524180