### PR TITLE
Fix custom dispatcher SSL errors and socket timeouts

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -12,7 +12,7 @@ from ._exceptions import (
     WebSocketException,
     WebSocketTimeoutException,
 )
-from ._ssl_compat import SSLEOFError
+from ._ssl_compat import SSLError
 from ._url import parse_url
 from ._dispatcher import Dispatcher, DispatcherBase, SSLDispatcher, WrappedDispatcher
 
@@ -468,8 +468,9 @@ class WebSocketApp:
             except (
                 WebSocketConnectionClosedException,
                 KeyboardInterrupt,
-                SSLEOFError,
+                SSLError,
                 ConnectionResetError,
+                WebSocketTimeoutException,
             ) as e:
                 if custom_dispatcher:
                     return closed(e)

--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -353,6 +353,7 @@ class WebSocketApp:
         self.ping_timeout = ping_timeout
         self.ping_payload = ping_payload
         self.has_done_teardown = False
+        self.has_errored = False
         self.keep_running = True
 
         def teardown(close_frame: Optional[ABNF] = None) -> None:
@@ -565,7 +566,8 @@ class WebSocketApp:
             reconnecting: bool = False,
             close_frame: Optional[ABNF] = None,
         ) -> bool:
-            self.has_errored = True
+            if close_frame is None:
+                self.has_errored = True
             self._stop_ping_thread()
             if not reconnecting:
                 self._callback(self.on_error, e)


### PR DESCRIPTION
When using a custom dispatcher (e.g. Gevent), exceptions raised inside the read() callback propagate into the external event loop rather than the outer try/except in initialize_socket(). The inner except in read() is the only interception point for the custom-dispatcher code path.                                                                                                        

SSLEOFError was already caught, but other ssl.SSLError variants (bad record MAC, unexpected record, TLS alert on disconnect) and WebSocketTimeoutException (triggered when a configured socket timeout expires during recv, including via the SSLWantReadError retry path) could escape uncaught and crash the dispatcher's event loop.

Replace SSLEOFError with its parent SSLError to cover all SSL read errors, and add WebSocketTimeoutException to the same except tuple. Behaviour for non-custom-dispatcher connections is unchanged: both exceptions are re-raised and caught by the existing outer handler.