### PR TITLE
Release resources when using a custom dispatcher

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     python_requires=">=3.10",
     extras_require={
         "test": ["pytest", "websockets"],
-        "optional": ["python-socks", "wsaccel"],
+        "optional": ["python-socks", "wsaccel", "rel >= 0.4.9.27"],
         "docs": ["Sphinx >= 6.0", "sphinx_rtd_theme >= 1.1.0", "myst-parser >= 2.0.0"],
     },
     classifiers=[

--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -355,6 +355,7 @@ class WebSocketApp:
         self.has_done_teardown = False
         self.has_errored = False
         self.keep_running = True
+        self.reconnect_pending = False
 
         def teardown(close_frame: Optional[ABNF] = None) -> None:
             """
@@ -399,6 +400,9 @@ class WebSocketApp:
         def initialize_socket(reconnecting: bool = False) -> None:
             if reconnecting and self.sock:
                 self.sock.shutdown()
+
+            if reconnecting:
+                self.reconnect_pending = False
 
             # Reset close frame to avoid stale data from previous connections
             self.last_close_frame = None
@@ -579,7 +583,8 @@ class WebSocketApp:
 
             if reconnect:
                 info(f"{e} - reconnect")
-                if custom_dispatcher:
+                if custom_dispatcher and not self.reconnect_pending:
+                    self.reconnect_pending = True
                     debug(
                         f"Calling custom dispatcher reconnect [{len(inspect.stack())} frames in stack]"
                     )

--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -478,12 +478,16 @@ class WebSocketApp:
                 WebSocketTimeoutException,
             ) as e:
                 if custom_dispatcher:
-                    return closed(e)
+                    closed(e)
+                    # Stop reading from this connection
+                    return False
                 else:
                     raise e
 
             if op_code == ABNF.OPCODE_CLOSE:
-                return closed(frame)
+                closed(frame)
+                # Stop reading from this connection
+                return False
             elif op_code == ABNF.OPCODE_PING:
                 self._callback(self.on_ping, frame.data)
             elif op_code == ABNF.OPCODE_PONG:

--- a/websocket/_core.py
+++ b/websocket/_core.py
@@ -596,6 +596,8 @@ class WebSocket:
         close socket, immediately.
         """
         if self.sock:
+            if self.dispatcher:
+                self.dispatcher.release_sock(self.sock)
             try:
                 # Check if socket is still open before closing
                 if not self.sock._closed:
@@ -623,6 +625,8 @@ class WebSocket:
             return recv(self.sock, bufsize)
         except WebSocketConnectionClosedException:
             if self.sock:
+                if self.dispatcher:
+                    self.dispatcher.release_sock(self.sock)
                 self.sock.close()
             self.sock = None
             self.connected = False

--- a/websocket/_dispatcher.py
+++ b/websocket/_dispatcher.py
@@ -3,6 +3,7 @@ import socket
 import inspect
 import selectors
 from typing import Any, TYPE_CHECKING, Callable, Optional, Union
+from collections import defaultdict
 
 if TYPE_CHECKING:
     from ._app import WebSocketApp
@@ -58,6 +59,9 @@ class DispatcherBase:
 
     def send(self, sock: socket.socket, data: Union[str, bytes]) -> int:
         return send(sock, data)
+
+    def release_sock(self, sock: socket.socket) -> None:
+        pass
 
 
 class Dispatcher(DispatcherBase):
@@ -142,6 +146,7 @@ class WrappedDispatcher:
         self.ping_timeout = ping_timeout
         self.dispatcher = dispatcher
         self.handleDisconnect = handleDisconnect
+        self.sock_events = defaultdict(list)
         dispatcher.signal(2, dispatcher.abort)  # keyboard interrupt
 
     def read(
@@ -150,9 +155,12 @@ class WrappedDispatcher:
         read_callback: Callable,
         check_callback: Callable,
     ) -> None:
-        self.dispatcher.read(sock, read_callback)
+        events = self.sock_events[sock]
+        read_ev = self.dispatcher.read(sock, read_callback)
+        events.append(read_ev)
         if self.ping_timeout:
-            self.timeout(self.ping_timeout, check_callback)
+            ping_ev = self.dispatcher.timeout(self.ping_timeout, check_callback)
+            events.append(ping_ev)
 
     def send(self, sock: socket.socket, data: Union[str, bytes]) -> int:
         self.dispatcher.buffwrite(sock, data, send, self.handleDisconnect)
@@ -163,3 +171,8 @@ class WrappedDispatcher:
 
     def reconnect(self, seconds: int, reconnector: Callable) -> None:
         self.timeout(seconds, reconnector, True)
+
+    def release_sock(self, sock: socket.socket) -> None:
+        # Remove READ event and timer
+        for ev in self.sock_events.pop(sock, []):
+            ev.delete()

--- a/websocket/_dispatcher.py
+++ b/websocket/_dispatcher.py
@@ -176,3 +176,5 @@ class WrappedDispatcher:
         # Remove READ event and timer
         for ev in self.sock_events.pop(sock, []):
             ev.delete()
+        # Remove the WRITE and ERROR events
+        self.dispatcher.release_buff(sock)


### PR DESCRIPTION
This PR adds the `DispatcherBase.release_sock()` method which is called when closing the socket, in order to release the resources associated with it. Only implemented for the custom dispatcher case, so that events and timers are unregistered there (they are tracked on creation).

For WRITE events, this relies on the `release_buff()` method introduced in version 0.4.9.27 of rel, hence the indication in "setup.py".
This is not compatible with other custom dispatchers like pyevent, but such a compatibility was already broken in the past anyway, once `WrappedDispatcher` uses the `buffwrite()` method.

All the changes to "_app.py" (last 2 commits) are not exactly related to this PR, but I didn't feel like they would need their own PR. They prevent the reconnect timer to be spawned multiple times in parallel and the `read()` method to be called in loop on socket with errors (until the socket is closed eventually). Please see the commit messages for details.