### PR TITLE
fix: replace bare except clauses with specific exception types

### DIFF
--- a/websocket/_core.py
+++ b/websocket/_core.py
@@ -579,7 +579,7 @@ class WebSocket:
             if self.sock is not None:
                 self.sock.settimeout(sock_timeout)
                 self.sock.shutdown(socket.SHUT_RDWR)
-        except:
+        except OSError:
             pass
 
         self.shutdown()

--- a/websocket/_wsdump.py
+++ b/websocket/_wsdump.py
@@ -192,14 +192,14 @@ def main() -> None:
             ):  # gzip magick
                 try:
                     data = "[gzip] " + str(gzip.decompress(data), "utf-8")
-                except:
+                except (OSError, EOFError, zlib.error, UnicodeDecodeError):
                     pass
             elif isinstance(data, bytes):
                 try:
                     data = "[zlib] " + str(
                         zlib.decompress(data, -zlib.MAX_WBITS), "utf-8"
                     )
-                except:
+                except (zlib.error, UnicodeDecodeError):
                     pass
 
             if isinstance(data, bytes):


### PR DESCRIPTION
Fix 3 bare `except:` clauses that catch `BaseException` (including `SystemExit`, `KeyboardInterrupt`), replacing them with specific exception types.

### Changes

**`websocket/_wsdump.py`:**
- **Line 195**: `except:` → `except (OSError, EOFError, zlib.error, UnicodeDecodeError):` — wraps `gzip.decompress(data)` which can raise `OSError`/`BadGzipFile`, `EOFError` on truncated data, `zlib.error` on compression errors; the `str(..., "utf-8")` can raise `UnicodeDecodeError`.
- **Line 202**: `except:` → `except (zlib.error, UnicodeDecodeError):` — wraps `zlib.decompress(data, -zlib.MAX_WBITS)` which raises `zlib.error`; the `str(..., "utf-8")` can raise `UnicodeDecodeError`.

**`websocket/_core.py`:**
- **Line 582**: `except:` → `except OSError:` — wraps `self.sock.shutdown(socket.SHUT_RDWR)` which raises `OSError` when the socket is already closed or not connected; comment says "ignore errors."

Bare `except:` clauses are bad practice (PEP 8 / flake8 E722) because they silently swallow `KeyboardInterrupt` and `SystemExit`, which can prevent clean program shutdown.