### PR TITLE
Fix race in WebSocketApp.close() when run_forever thread clears sock

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -205,11 +205,12 @@ class WebSocketApp:
         Close websocket connection.
         """
         self.keep_running = False
-        if self.sock:
-            self.sock.close(**kwargs)
+        sock = self.sock
+        if sock:
+            sock.close(**kwargs)
             # Capture the peer's close frame before clearing socket reference
-            if self.sock.close_frame is not None:
-                self.last_close_frame = self.sock.close_frame
+            if sock.close_frame is not None:
+                self.last_close_frame = sock.close_frame
             self.sock = None
 
     def _start_ping_thread(self) -> None:

--- a/websocket/tests/test_app.py
+++ b/websocket/tests/test_app.py
@@ -784,6 +784,46 @@ class WebSocketAppUnitTests(unittest.TestCase):
 
         self.assertEqual(close_results, [(1000, "peer-goodbye")])
 
+    def test_close_captures_frame_when_teardown_clears_socket(self):
+        """close() retains its socket while concurrent teardown clears app.sock."""
+        app = self._build_app()
+        peer_close_frame = ABNF.create_frame(
+            struct.pack("!H", 1000) + b"peer-goodbye", ABNF.OPCODE_CLOSE
+        )
+        close_started = threading.Event()
+        allow_close_to_return = threading.Event()
+        errors = []
+
+        class FakeWebSocket:
+            close_frame = None
+
+            def close(self, **kwargs):
+                self.close_frame = peer_close_frame
+                close_started.set()
+                if not allow_close_to_return.wait(timeout=1):
+                    raise TimeoutError("test did not release FakeWebSocket.close()")
+
+        app.sock = FakeWebSocket()
+
+        def close_app():
+            try:
+                app.close()
+            except Exception as error:
+                errors.append(error)
+
+        close_thread = threading.Thread(target=close_app)
+        close_thread.start()
+        self.assertTrue(close_started.wait(timeout=1))
+
+        # This models run_forever() teardown clearing the shared app reference.
+        app.sock = None
+        allow_close_to_return.set()
+        close_thread.join(timeout=1)
+
+        self.assertFalse(close_thread.is_alive())
+        self.assertEqual(errors, [])
+        self.assertIs(app.last_close_frame, peer_close_frame)
+
     def test_last_close_frame_reset_on_reconnect(self):
         """Test that last_close_frame is reset when initializing a new socket."""
         app = self._build_app()


### PR DESCRIPTION
Version 1.9.1 introduced a crash when WebSocketApp.close() is called from a different thread than the one running run_forever(). Commit 10d9159 (PR #1044) changed close() so that it reads self.sock.close_frame after calling self.sock.close(). While self.sock.close() is waiting for the close handshake to finish, the run_forever() thread notices the connection is closing, runs teardown() and sets self.sock to None. When close() then reads self.sock.close_frame it raises AttributeError because self.sock is gone. Versions up to 1.9.0 never touched self.sock again after closing it, so this crash could not happen there. The fix is for close() to keep a local reference to the socket and use that for the whole method, so it never reads self.sock after another thread has cleared it.

Fixes #1056