### PR TITLE
Accept a handshake response with no subprotocol selected

### DIFF
--- a/websocket/_handshake.py
+++ b/websocket/_handshake.py
@@ -198,10 +198,11 @@ def _validate(headers: dict, key: str, subprotocols: Optional[List[str]]) -> tup
 
     if subprotocols:
         subproto = headers.get("sec-websocket-protocol", None)
-        if not subproto or subproto.lower() not in [s.lower() for s in subprotocols]:
-            error(f"Invalid subprotocol: {subprotocols}")
-            return False, None
-        subproto = subproto.lower()
+        if subproto:
+            if subproto.lower() not in [s.lower() for s in subprotocols]:
+                error(f"Invalid subprotocol: {subprotocols}")
+                return False, None
+            subproto = subproto.lower()
 
     result = headers.get("sec-websocket-accept", None)
     if not result:

--- a/websocket/tests/test_websocket.py
+++ b/websocket/tests/test_websocket.py
@@ -162,8 +162,9 @@ class WebSocketTest(unittest.TestCase):
         )
 
         header = required_header.copy()
-        # This case will print out a logging error using the error() function, but that is expected
-        self.assertEqual(_validate_header(header, key, ["Sub1", "suB2"]), (False, None))
+        # Server omitting the header entirely is a valid response per RFC 6455;
+        # it means no subprotocol was selected, not that the handshake is invalid.
+        self.assertEqual(_validate_header(header, key, ["Sub1", "suB2"]), (True, None))
 
     def test_read_header(self):
         status, header, _ = read_headers(HeaderSockMock("data/header01.txt"))


### PR DESCRIPTION
Fixes #1027

RFC 6455 makes the server's Sec-WebSocket-Protocol header optional in its handshake response even when the client asked for subprotocols. Leaving it out just means no subprotocol was selected, and every browser WebSocket implementation treats that as a plain, successful connection. This library instead raised `Invalid subprotocol` any time that header was missing, even though the server was never required to include it.

The relevant check is in `_validate()`:

```python
if subprotocols:
    subproto = headers.get("sec-websocket-protocol", None)
    if not subproto or subproto.lower() not in [s.lower() for s in subprotocols]:
        error(f"Invalid subprotocol: {subprotocols}")
        return False, None
    subproto = subproto.lower()
```

`not subproto` fails the handshake whenever the header is absent, treating "server didn't pick one" the same as "server picked something we didn't ask for." Now it only compares against the requested list when the server actually sent a value; if it's missing, the handshake proceeds with `subprotocol` left as `None`, matching what a browser reports in the same situation.

The existing test suite already had this exact scenario covered, it just asserted the old behavior (`(False, None)`), so I updated that expectation to `(True, None)` rather than adding a parallel test for the same case.

Ran the full `test_websocket.py` suite (35 passed, 11 skipped, the skips are pre-existing ones needing a live socket) and `black --check` on both touched files.