### PR TITLE
fix auto gc websocketapp 

### DIFF
--- a/websocket/_app.py
+++ b/websocket/_app.py
@@ -2,6 +2,8 @@ import inspect
 import socket
 import threading
 import time
+import gc
+import types
 from typing import Any, Callable, List, Optional, Tuple, Union
 
 from ._logging import debug, error, info, warning
@@ -520,7 +522,29 @@ class WebSocketApp:
                     )
                 ):
                     raise WebSocketTimeoutException("ping/pong timed out")
+            refs=gc.get_referrers(self)
+            _l=[is_my_runtime_object(x) for x in refs ]
+            
+            if  all(_l):
+                info(r''' only cycle ref exit''')
+                raise SystemExit("lifecycle ended")
             return True
+        def is_my_runtime_object(obj):
+            '''            
+            '''
+            
+            if isinstance(obj , types.CellType):
+
+                return obj.cell_contents is self
+            if isinstance(obj,types.MethodType):
+
+                return obj.__self__ is self and obj.__func__ is self.__class__.run_forever
+            if  isinstance(obj,dispatcher.__class__):
+
+                    
+                return obj is dispatcher
+  
+            return False
 
         def closed(
             e: Union[
@@ -612,7 +636,16 @@ class WebSocketApp:
             if not custom_dispatcher:
                 # Ensure teardown was called before returning from run_forever
                 teardown()
+            del closed
+            del initialize_socket
+            del handleDisconnect
+            del check
+            del read
+            del teardown
+            del dispatcher
 
+ 
+            gc.collect()  #  gc
         return self.has_errored
 
     def create_dispatcher(
@@ -690,3 +723,7 @@ class WebSocketApp:
                 # when the failing callback IS on_error itself
                 if self.on_error and callback is not self.on_error:
                     self.on_error(self, e)
+
+
+    # def __del__(self):
+    #     print('app_del called id:',id(self))

--- a/websocket/_dispatcher.py
+++ b/websocket/_dispatcher.py
@@ -58,6 +58,8 @@ class DispatcherBase:
 
     def send(self, sock: socket.socket, data: Union[str, bytes]) -> int:
         return send(sock, data)
+    # def __del__(self):
+    #     print( 'dispatcher del called:',id(self))
 
 
 class Dispatcher(DispatcherBase):


### PR DESCRIPTION
```

import threading,json,time
import rel
from websocket import WebSocketApp
import websocket
websocket.enableTrace(True)
wsurl='ws://127.0.0.1:57915/devtools/browser/590396f0-f89d-4c23-b387-d99cdca223e6' #replace as yours
class A:
    ...

a=A()
def _on_message(ws,data):
    print(data)



a._websocket=WebSocketApp(wsurl,on_message=_on_message)

print(rf'''{id(a._websocket)=}''')  # the old one will never auto gc

t=threading.Thread(target=a._websocket.run_forever,kwargs={'reconnect':1,'ping_timeout':10.0},daemon=True)
t.start()
while not a._websocket.ready():
    time.sleep(0.1)
a._websocket.send(json.dumps({"id":1,"method":"Browser.getVersion","params":{}}))
time.sleep(10) #make sure no error when recv
a._websocket=WebSocketApp(wsurl,on_message=_on_message)  # new instance 
print(rf'''{id(a._websocket)=}''')

_websocket=WebSocketApp(wsurl,on_message=_on_message) 
print(rf'''{id(_websocket)=}''')
_websocket.run_forever(dispatcher=rel, reconnect=5)  # Set dispatcher to automatic reconnection, 5 second reconnect delay if connection closed unexpectedly
rel.signal(2, rel.abort)  # Keyboard Interrupt
rel.dispatch()
```

`WebSocketApp` cannot be automatically garbage-collected.
If the application no longer has an outer reference to the `WebSocketApp`, there is no way to access the app and call `app.close()`. so the `app.keep_running` will always `True`.
dispatcher will try reconnect until ```(KeyboardInterrupt, SystemExit)```  
top code shows the old one can not auto gc 1.  but the new can gc the first app. the 2. and 3. do not need gc.
